### PR TITLE
feat: dgenies-fidelity contig sort, reordered/reoriented FASTA export, Python 3.14

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: "3.12"
+          python-version: "3.14"
       - name: Install Rust stable
         uses: dtolnay/rust-toolchain@stable
       - name: Cache cargo registry
@@ -107,7 +107,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: "3.12"
+          python-version: "3.14"
       - name: Cache cargo registry
         uses: actions/cache@v5
         with:
@@ -148,6 +148,8 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
+          # Pinned to 3.12: Pyodide 0.27 (emsdk 3.1.65 above) ships CPython 3.12,
+          # so the wasm wheel must be built with a matching interpreter.
           python-version: "3.12"
       - name: Cache cargo registry
         uses: actions/cache@v5

--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.12'
+          python-version: '3.14'
       # The bench binary links `rustydot` (an rlib), which pulls in pyo3 built
       # without the `extension-module` feature, so it dynamically links
       # libpython. Pin the interpreter for the build and expose its lib dir so
@@ -49,7 +49,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.12'
+          python-version: '3.14'
       # maturin needs cargo to build the extension from the sdist/source tree.
       - uses: dtolnay/rust-toolchain@stable
       - name: Build rustydot and install benchmark dependencies

--- a/README.md
+++ b/README.md
@@ -31,7 +31,12 @@ hits detected via `compare_sequences_stranded`
   short/spurious hits before rendering
 - Cross-index comparisons between two sequence sets (e.g. two genome assemblies)
 - Relative sequence scaling in dotplot subpanels
-- Gravity-centre contig ordering for maximum collinearity
+- d-genies-style gravity contig ordering for maximum collinearity: matches are
+  weighted by `(1 + euclidean_length)²`, each contig is assigned to its single
+  best-matching chromosome, and reverse-oriented contigs are detected and can be
+  rendered flipped along the main diagonal (`DotPlotter.plot(reverse_contigs=…)`)
+- Export the collinearity layout to FASTA (`CrossIndex.write_fasta()`): contigs
+  written in the reordered order with reverse-oriented contigs reverse-complemented
 - **`PafAlignment.filter_by_min_length()`** — discard short alignment records from a loaded PAF file
 - Full Python bindings via [PyO3](https://pyo3.rs)
 
@@ -144,8 +149,12 @@ cross.load_fasta("genome_a.fasta", group="a")   # query sequences (rows)
 cross.load_fasta("genome_b.fasta", group="b")   # target sequences (columns)
 
 # --- Sort contigs for maximum collinearity ---
-# Option 1: via CrossIndex (delegates to SequenceIndex.optimal_contig_order)
+# Option 1: via CrossIndex (delegates to SequenceIndex.optimal_contig_order).
+# Each query contig is assigned to its best-matching target chromosome and
+# ordered by its gravity centre there; reverse-oriented contigs are detected
+# and exposed via cross.reversed_contigs("a").
 q_sorted, t_sorted = cross.reorder_contigs()
+reversed_a = cross.reversed_contigs("a")  # names to render flipped
 
 # Option 2: via PafAlignment gravity-centre algorithm
 # Retrieve all cross-group PAF lines
@@ -168,6 +177,9 @@ plotter.plot(
     output_path="cross_dotplot.png",
     scale_sequences=True,   # subplot size proportional to sequence length
     title="Genome A vs Genome B",
+    # Render reverse-oriented query contigs flipped so they read along the main
+    # diagonal.  Pass an explicit set, or omit to auto-pull the detected set.
+    reverse_contigs=reversed_a,
 )
 
 # Save as SVG vector image for publication-quality output
@@ -188,6 +200,13 @@ plotter.plot(
     min_length=500,
     title="Genome A vs Genome B (≥500 bp alignments)",
 )
+
+# --- Persist the collinearity layout as FASTA ---
+# Reorder + reorient assembly B against a FIXED assembly A, then write both.
+# Reverse-oriented B contigs are reverse-complemented on write; A is untouched.
+cross.reorder_for_colinearity("b", "a", reorder_target=False)
+cross.write_fasta("assembly_a.sorted.fasta", "a")  # forward reference, unchanged
+cross.write_fasta("assembly_b.sorted.fasta", "b")  # reordered + reoriented
 ```
 
 ## Filtering PAF Alignments by Length

--- a/docs/api/cross_index.md
+++ b/docs/api/cross_index.md
@@ -12,6 +12,8 @@ Loading sequences and computing matches are **separate explicit steps**:
 2. Call `compute_matches()` to compute k-mer matches between groups.
 3. Call `reorder_contigs()` or `reorder_for_colinearity()` (requires step 2).
 4. Plot with `DotPlotter` using `query_group` / `target_group` to specify groups.
+5. Optionally persist the layout with `write_fasta()` — contigs are written in
+   the reordered order with reverse-oriented contigs reverse-complemented.
 
 Progress is logged at `INFO` level for each loading and computation step.
 Warnings are emitted when a sequence name already exists in the same or
@@ -38,17 +40,49 @@ cross.load_fasta("assembly_b.fasta", group="b")
 cross.compute_matches()
 print("Computed pairs:", cross.computed_group_pairs)
 
-# Sort contigs for maximum collinearity
+# Sort contigs for maximum collinearity.  Each query contig is assigned to its
+# best-matching target chromosome (argmax of the squared match weights) and
+# ordered by its gravity centre there; reverse-oriented contigs are detected.
 q_sorted, t_sorted = cross.reorder_contigs()
+reversed_a = cross.reversed_contigs("a")  # query contigs to render flipped
 
-# Plot directly from CrossIndex — sequence names resolved via group params
+# Plot directly from CrossIndex — sequence names resolved via group params.
+# Reverse-oriented contigs are rendered flipped so they read along the main
+# diagonal.  Omit reverse_contigs to auto-pull the detected set for query_group.
 plotter = DotPlotter(cross)
 plotter.plot(
     query_group="a",   # sequences from group 'a' as rows
     target_group="b",  # sequences from group 'b' as columns
     output_path="cross_plot.png",
+    reverse_contigs=reversed_a,
 )
 ```
+
+## Writing reordered / reoriented FASTA
+
+`write_fasta()` persists a group's contigs in the current
+[`contig_order`](#rusty_dot.paf_io.CrossIndex.contig_order), reverse-complementing
+any contig flagged by [`reversed_contigs()`](#rusty_dot.paf_io.CrossIndex.reversed_contigs).
+Orientation is always expressed relative to the target group, which stays the
+forward reference — so reorder the group you want to *change* as the **query**.
+
+```python
+cross = CrossIndex(k=15)
+cross.load_fasta("assembly_a.fasta", group="a")
+cross.load_fasta("assembly_b.fasta", group="b")
+cross.compute_matches(query_group="b", target_group="a")
+
+# Reorder + reorient B against a FIXED A (A is not moved or flipped):
+cross.reorder_for_colinearity("b", "a", reorder_target=False)
+
+cross.write_fasta("assembly_a.sorted.fasta", "a")  # unchanged reference
+cross.write_fasta("assembly_b.sorted.fasta", "b")  # reordered + reoriented
+```
+
+Pass `reorder_target=True` (the default) to let both assemblies be reordered;
+A remains the forward reference and B's contigs are the ones reverse-complemented.
+`reorder_by_length(group)` sets a length-sorted order for a group before writing.
+See the *Writing Reordered FASTA* tutorial for full worked examples.
 
 ## Custom group names
 

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -27,4 +27,6 @@ rusty-dot exposes its functionality through the following classes and functions.
 | [`py_save_index`](functions.md#rusty_dot._rusty_dot.py_save_index) | `rusty_dot` | Serialise an index collection to disk |
 | [`py_load_index`](functions.md#rusty_dot._rusty_dot.py_load_index) | `rusty_dot` | Load a serialised index from disk |
 | [`parse_paf_file`](paf_io.md#rusty_dot.paf_io.parse_paf_file) | `rusty_dot.paf_io` | Yield PAF records from a file |
-| [`compute_gravity_contigs`](paf_io.md#rusty_dot.paf_io.compute_gravity_contigs) | `rusty_dot.paf_io` | Sort contigs by gravity centre |
+| [`compute_gravity_contigs`](paf_io.md#rusty_dot.paf_io.compute_gravity_contigs) | `rusty_dot.paf_io` | Sort contigs by best-chromosome gravity centre; report reverse-oriented contigs |
+| [`compute_reversed_contigs`](paf_io.md#rusty_dot.paf_io.compute_reversed_contigs) | `rusty_dot.paf_io` | Detect reverse-oriented query contigs (d-genies orientation check) |
+| [`reverse_complement`](paf_io.md#rusty_dot.paf_io.reverse_complement) | `rusty_dot.paf_io` | Reverse-complement a nucleotide string |

--- a/docs/api/paf_io.md
+++ b/docs/api/paf_io.md
@@ -37,3 +37,7 @@ plotter.plot(
 ::: rusty_dot.paf_io.parse_paf_file
 
 ::: rusty_dot.paf_io.compute_gravity_contigs
+
+::: rusty_dot.paf_io.compute_reversed_contigs
+
+::: rusty_dot.paf_io.reverse_complement

--- a/docs/tutorials/all_vs_all_two_indices.ipynb
+++ b/docs/tutorials/all_vs_all_two_indices.ipynb
@@ -31,14 +31,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Sequences for \"genome A\" \u2014 three contigs of different lengths\n",
+    "# Sequences for \"genome A\" — three contigs of different lengths\n",
     "genome_a = {\n",
     "    'contigA1': 'ACGTACGTACGTACGTACGT' * 10,  # 200 bp\n",
     "    'contigA2': 'TACGTACGTACGTACGTACG' * 5,  # 100 bp\n",
     "    'contigA3': 'GCGCGCGCGCGCGCGCGCGC' * 3,  # 60 bp\n",
     "}\n",
     "\n",
-    "# Sequences for \"genome B\" \u2014 three contigs\n",
+    "# Sequences for \"genome B\" — three contigs\n",
     "genome_b = {\n",
     "    'contigB1': 'ACGTACGTACGTACGTACGT' * 8,  # 160 bp  (similar to contigA1)\n",
     "    'contigB2': 'GCGCGCGCGCGCGCGCGCGC' * 4,  # 80 bp   (similar to contigA3)\n",
@@ -75,7 +75,7 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": "## 3. Compute cross-group k-mer matches\n\nCall `compute_matches()` before retrieving PAF lines or reordering contigs.\nThis is the explicit computation step \u2014 matches are **not** calculated automatically\nwhen loading sequences."
+   "source": "## 3. Compute cross-group k-mer matches\n\nCall `compute_matches()` before retrieving PAF lines or reordering contigs.\nThis is the explicit computation step — matches are **not** calculated automatically\nwhen loading sequences."
   },
   {
    "cell_type": "code",
@@ -117,7 +117,7 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": "## 5. Build a combined index for plotting (optional)\n\n> **Note:** You can now plot directly from a `CrossIndex` using `query_group` and\n> `target_group` parameters \u2014 see step 6.  The combined index below is only needed\n> when using `DotPlotter` without group params.\n\n`DotPlotter` requires a single `SequenceIndex` containing all sequences to be\nplotted when not using the group-based API.  The cell below creates one from both\ngenomes."
+   "source": "## 5. Build a combined index for plotting (optional)\n\n> **Note:** You can now plot directly from a `CrossIndex` using `query_group` and\n> `target_group` parameters — see step 6.  The combined index below is only needed\n> when using `DotPlotter` without group params.\n\n`DotPlotter` requires a single `SequenceIndex` containing all sequences to be\nplotted when not using the group-based API.  The cell below creates one from both\ngenomes."
   },
   {
    "cell_type": "code",
@@ -146,12 +146,12 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": "import matplotlib.pyplot as plt\n\n# Plot directly from CrossIndex \u2014 no separate combined_idx needed\nplotter = DotPlotter(cross)\n\nfig = plotter.plot(\n    query_group='a',     # sequence names looked up from group 'a'\n    target_group='b',    # sequence names looked up from group 'b'\n    figsize_per_panel=4.0,\n    scale_sequences=True,\n    title='Genome A vs Genome B \u2014 collinearity-sorted contigs',\n    dpi=100,\n)\nplt.close(fig)  # free memory when no longer needed\n"
+   "source": "import matplotlib.pyplot as plt\n\n# Plot directly from CrossIndex — no separate combined_idx needed\nplotter = DotPlotter(cross)\n\nfig = plotter.plot(\n    query_group='a',     # sequence names looked up from group 'a'\n    target_group='b',    # sequence names looked up from group 'b'\n    figsize_per_panel=4.0,\n    scale_sequences=True,\n    title='Genome A vs Genome B — collinearity-sorted contigs',\n    dpi=100,\n)\nplt.close(fig)  # free memory when no longer needed\n"
   },
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": "## Using `CrossIndex.reorder_contigs` directly\n\nA convenience wrapper is available on the `CrossIndex` object itself.  `compute_matches()` must have been called first \u2014 it is the explicit step that computes and caches k-mer matches between groups."
+   "source": "## Using `CrossIndex.reorder_contigs` directly\n\nA convenience wrapper is available on the `CrossIndex` object itself.  `compute_matches()` must have been called first — it is the explicit step that computes and caches k-mer matches between groups."
   },
   {
    "cell_type": "code",
@@ -159,6 +159,18 @@
    "metadata": {},
    "outputs": [],
    "source": "# compute_matches was already called above; calling reorder_contigs\nq_opt, t_opt = cross.reorder_contigs()\nprint('Optimal query order:', q_opt)\nprint('Optimal target order:', t_opt)\n"
+  },
+  {
+   "cell_type": "markdown",
+   "source": "## 7. Flip reverse-oriented contigs\n\n`reorder_contigs()` also detects query contigs that align in **reverse orientation**\nagainst their best-matching target chromosome (using the d-genies orientation\ncheck).  These are exposed via `cross.reversed_contigs(group)`.\n\nPassing that set to `DotPlotter.plot(reverse_contigs=...)` renders those contigs\nreverse-complemented so their alignments read along the **main diagonal** instead\nof the anti-diagonal — the underlying coordinates are never modified, only the\nrendering.  Omitting the argument auto-pulls the detected set for `query_group`.",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "source": "# Query contigs detected as reverse-oriented against their best chromosome\nreversed_a = cross.reversed_contigs('a')\nprint('Reverse-oriented query contigs:', reversed_a)\n\n# Render them flipped so they read along the main diagonal.  (Omit the\n# reverse_contigs argument to auto-pull this same set for query_group='a'.)\nfig = plotter.plot(\n    query_group='a',\n    target_group='b',\n    figsize_per_panel=4.0,\n    scale_sequences=True,\n    title='Reverse-oriented contigs flipped onto the main diagonal',\n    dpi=100,\n    reverse_contigs=reversed_a,\n)\nplt.close(fig)\n",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
   }
  ],
  "metadata": {

--- a/docs/tutorials/write_reordered_fasta.ipynb
+++ b/docs/tutorials/write_reordered_fasta.ipynb
@@ -1,0 +1,270 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "4a2a000c",
+   "metadata": {},
+   "source": [
+    "# Writing Reordered and Reoriented FASTA\n",
+    "\n",
+    "When you optimise a dotplot for collinearity, you often want to persist that\n",
+    "layout as an actual FASTA file: contigs written in the collinearity-sorted\n",
+    "order, with reverse-oriented contigs reverse-complemented so they read forward.\n",
+    "\n",
+    "`CrossIndex` supports this via:\n",
+    "\n",
+    "- `reorder_for_colinearity(query_group, target_group, reorder_target=...)` — sort\n",
+    "  (and detect reverse orientation for) the query group; set `reorder_target=False`\n",
+    "  to leave the target group's order **fixed**.\n",
+    "- `reorder_by_length(group)` — sort a group by descending length.\n",
+    "- `reversed_contigs(group)` — the contigs detected as reverse-oriented.\n",
+    "- `write_fasta(path, group, order=..., reverse=...)` — write a group to FASTA in\n",
+    "  the current (or a given) order, reverse-complementing the flagged contigs.\n",
+    "\n",
+    "> **Orientation is relative.** A contig is only \"reversed\" *with respect to a\n",
+    "> reference*. Throughout this tutorial **Assembly A is the forward reference**:\n",
+    "> its bases are never flipped; Assembly B is reoriented to match it.\n",
+    "\n",
+    "This tutorial shows three scenarios."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d2f385c1",
+   "metadata": {},
+   "source": [
+    "## Setup: two toy assemblies\n",
+    "\n",
+    "Assembly **A** has three contigs (`chrA`, `chrB`, `chrC`). Assembly **B** contains\n",
+    "the same three sequences but **shuffled**, with the copy of `chrC` **reverse\n",
+    "complemented** — exactly the kind of mess a fresh assembly produces."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ccf2daae",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import random\n",
+    "import tempfile\n",
+    "from pathlib import Path\n",
+    "\n",
+    "from rusty_dot.paf_io import CrossIndex, reverse_complement\n",
+    "\n",
+    "\n",
+    "def random_dna(length, seed):\n",
+    "    rng = random.Random(seed)\n",
+    "    return ''.join(rng.choice('ACGT') for _ in range(length))\n",
+    "\n",
+    "\n",
+    "# Assembly A: three distinct, non-repetitive contigs.\n",
+    "chrA = random_dna(400, seed=1)\n",
+    "chrB = random_dna(320, seed=2)\n",
+    "chrC = random_dna(260, seed=3)\n",
+    "\n",
+    "assembly_a = {'chrA': chrA, 'chrB': chrB, 'chrC': chrC}\n",
+    "\n",
+    "# Assembly B: same sequences, shuffled, with the chrC copy reverse-complemented.\n",
+    "assembly_b = {\n",
+    "    'utg1': chrB,                      # matches chrB (forward)\n",
+    "    'utg2': reverse_complement(chrC),  # matches chrC (reverse-oriented!)\n",
+    "    'utg3': chrA,                      # matches chrA (forward)\n",
+    "}\n",
+    "\n",
+    "print('Assembly A order:', list(assembly_a))\n",
+    "print('Assembly B order:', list(assembly_b))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d0dcd751",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def build_cross():\n",
+    "    \"\"\"Fresh CrossIndex with A in group 'a' and B in group 'b'.\"\"\"\n",
+    "    cross = CrossIndex(k=13)\n",
+    "    for name, seq in assembly_a.items():\n",
+    "        cross.add_sequence(name, seq, group='a')\n",
+    "    for name, seq in assembly_b.items():\n",
+    "        cross.add_sequence(name, seq, group='b')\n",
+    "    # Matches with B as query and A as target (A is the reference axis).\n",
+    "    cross.compute_matches(query_group='b', target_group='a')\n",
+    "    return cross\n",
+    "\n",
+    "\n",
+    "def show_fasta(path):\n",
+    "    \"\"\"Print FASTA headers and sequence lengths from a file.\"\"\"\n",
+    "    for line in Path(path).read_text().splitlines():\n",
+    "        if line.startswith('>'):\n",
+    "            print(line)\n",
+    "\n",
+    "\n",
+    "tmp = Path(tempfile.mkdtemp())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1f9608ff",
+   "metadata": {},
+   "source": [
+    "## Case 1 — Reorder + reorient B to match A, leaving A untouched\n",
+    "\n",
+    "`reorder_for_colinearity('b', 'a', reorder_target=False)` sorts and orients\n",
+    "**B** against **A** while keeping A exactly as loaded. We then write A verbatim\n",
+    "and B in its new order with `utg2` reverse-complemented."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9e5002c3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cross = build_cross()\n",
+    "cross.reorder_for_colinearity('b', 'a', reorder_target=False)\n",
+    "\n",
+    "print('A order (unchanged):', cross.contig_order['a'])\n",
+    "print('B order (optimised):', cross.contig_order['b'])\n",
+    "print('B reverse-oriented :', cross.reversed_contigs('b'))\n",
+    "\n",
+    "cross.write_fasta(tmp / 'case1_A.fasta', 'a')  # forward reference, original order\n",
+    "cross.write_fasta(tmp / 'case1_B.fasta', 'b')  # reordered + reoriented\n",
+    "\n",
+    "print('\\n--- case1_A.fasta ---')\n",
+    "show_fasta(tmp / 'case1_A.fasta')\n",
+    "print('--- case1_B.fasta ---')\n",
+    "show_fasta(tmp / 'case1_B.fasta')\n",
+    "\n",
+    "# The written utg2 is reverse-complemented, so it now equals the forward chrC.\n",
+    "written = {}\n",
+    "for line in (tmp / 'case1_B.fasta').read_text().split('>'):\n",
+    "    if not line.strip():\n",
+    "        continue\n",
+    "    head, *seq = line.splitlines()\n",
+    "    written[head.split()[0]] = ''.join(seq)\n",
+    "assert written['utg2'] == chrC\n",
+    "print('\\nutg2 was flipped back to the forward orientation of chrC ✅')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bc3a9288",
+   "metadata": {},
+   "source": [
+    "## Case 2 — A sorted by length, B reordered + reoriented against it\n",
+    "\n",
+    "Here we first sort **A** by descending length (a deliberate, fixed layout), then\n",
+    "align **B** to that fixed order. A's *order* changes but its *strands* do not."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "46bd9103",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cross = build_cross()\n",
+    "cross.reorder_by_length('a')                                  # A: fixed, by length\n",
+    "cross.reorder_for_colinearity('b', 'a', reorder_target=False)  # B: aligned to A\n",
+    "\n",
+    "print('A order (by length):', cross.contig_order['a'])\n",
+    "print('B order (optimised):', cross.contig_order['b'])\n",
+    "print('B reverse-oriented :', cross.reversed_contigs('b'))\n",
+    "\n",
+    "cross.write_fasta(tmp / 'case2_A.fasta', 'a')\n",
+    "cross.write_fasta(tmp / 'case2_B.fasta', 'b')\n",
+    "print('\\n--- case2_A.fasta ---')\n",
+    "show_fasta(tmp / 'case2_A.fasta')\n",
+    "print('--- case2_B.fasta ---')\n",
+    "show_fasta(tmp / 'case2_B.fasta')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "eba50e24",
+   "metadata": {},
+   "source": [
+    "## Case 3 — Both assemblies reordered (A is the reference frame)\n",
+    "\n",
+    "With `reorder_target=True` (the default) **both** contig orders are optimised for\n",
+    "collinearity. Orientation still needs a fixed frame, so **A stays forward** and\n",
+    "**B** is reverse-complemented where needed. Both FASTA files are rewritten."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bc8322aa",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cross = build_cross()\n",
+    "cross.reorder_for_colinearity('b', 'a', reorder_target=True)\n",
+    "\n",
+    "print('A order (optimised):', cross.contig_order['a'])\n",
+    "print('B order (optimised):', cross.contig_order['b'])\n",
+    "print('B reverse-oriented :', cross.reversed_contigs('b'))\n",
+    "\n",
+    "cross.write_fasta(tmp / 'case3_A.fasta', 'a')\n",
+    "cross.write_fasta(tmp / 'case3_B.fasta', 'b')\n",
+    "print('\\n--- case3_A.fasta ---')\n",
+    "show_fasta(tmp / 'case3_A.fasta')\n",
+    "print('--- case3_B.fasta ---')\n",
+    "show_fasta(tmp / 'case3_B.fasta')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6e6822b6",
+   "metadata": {},
+   "source": [
+    "## Visual check\n",
+    "\n",
+    "A dotplot of the case-3 layout, with B's reverse-oriented contigs rendered\n",
+    "flipped, should show every block on the **main diagonal**. `DotPlotter` pulls the\n",
+    "reversed set automatically when `reverse_contigs` is omitted."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e873d2bd",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "from rusty_dot.dotplot import DotPlotter\n",
+    "\n",
+    "plotter = DotPlotter(cross)\n",
+    "fig = plotter.plot(\n",
+    "    query_group='b',\n",
+    "    target_group='a',\n",
+    "    scale_sequences=True,\n",
+    "    title='Case 3 — reordered + reoriented (B vs A)',\n",
+    "    dpi=100,\n",
+    ")\n",
+    "plt.close(fig)\n",
+    "print('Plotted collinear layout (reverse_contigs auto-detected).')"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/environment.yml
+++ b/environment.yml
@@ -4,9 +4,9 @@ channels:
   - bioconda
 dependencies:
   - pip
-  - python 3.13
+  - python 3.14
+  - python-freethreading
   - pip:
       - maturin
-      - pytest
       - matplotlib
       - numpy

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -67,6 +67,7 @@ nav:
       - Dotplot Visualization: tutorials/dotplot_tutorial.ipynb
       - PAF Workflow: tutorials/paf_workflow.ipynb
       - All-vs-All Between Two Indices: tutorials/all_vs_all_two_indices.ipynb
+      - Writing Reordered FASTA: tutorials/write_reordered_fasta.ipynb
       - Minimap2 PAF Visualization: tutorials/minimap2_paf_tutorial.ipynb
   - API Reference:
       - Overview: api/index.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ version = "0.1.0"
 description = "Fast dot plot comparisons of DNA sequences using an FM-Index"
 readme = "README.md"
 license = { file = "LICENSE" }
-requires-python = ">=3.9,<3.14"
+requires-python = ">=3.9,<3.15"
 keywords = ["bioinformatics", "dotplot", "fm-index", "sequence-comparison"]
 classifiers = [
     "Programming Language :: Rust",

--- a/python/benchmarks/test_bench_reorder.py
+++ b/python/benchmarks/test_bench_reorder.py
@@ -1,0 +1,81 @@
+"""CodSpeed benchmarks for the collinearity contig-reordering path.
+
+Run with ``pytest python/benchmarks --codspeed``.  These cover the d-genies
+gravity sort (squared weighting + best-matching-chromosome argmax) and the
+reverse-orientation detection added alongside it, on both the ``CrossIndex``
+(Rust ordering + Python reversal) and the pure-Python ``compute_gravity_contigs``
+paths.
+"""
+
+from __future__ import annotations
+
+from _synth import multi_contig_group, revcomp
+
+from rusty_dot.paf_io import CrossIndex, PafRecord, compute_gravity_contigs
+
+# Modest sizes so CodSpeed's instruction-count simulation stays quick while
+# still exercising a multi-contig, multi-target layout with inversions.
+_K = 15
+_N_CONTIGS = 5
+_CONTIG_LEN = 2000
+
+
+def _cross_with_matches() -> CrossIndex:
+    """Build a CrossIndex whose group B mirrors A, with half the contigs RC'd."""
+    contigs = multi_contig_group(_N_CONTIGS, _CONTIG_LEN, seed=7)
+    cross = CrossIndex(k=_K)
+    for name, seq in contigs:
+        cross.add_sequence(name, seq, group='A')
+    # Group B reuses A's sequences (so they align), reverse-complementing every
+    # other one to exercise reverse-orientation detection.
+    for i, (_name, seq) in enumerate(contigs):
+        cross.add_sequence(f'ref_{i}', revcomp(seq) if i % 2 else seq, group='B')
+    cross.compute_matches('A', 'B')
+    return cross
+
+
+def test_bench_reorder_for_colinearity(benchmark):
+    """Benchmark build + match + gravity reorder + reversal detection."""
+
+    def run():
+        cross = _cross_with_matches()
+        cross.reorder_for_colinearity('A', 'B')
+        return cross
+
+    benchmark(run)
+
+
+def _synthetic_records() -> list[PafRecord]:
+    """Fabricate a multi-target PAF record set (no k-mer engine involved)."""
+    records: list[PafRecord] = []
+    n_queries, n_targets, t_len = 40, 4, 5000
+    for q in range(n_queries):
+        best_t = q % n_targets
+        # A few collinear blocks against the best target, plus one small hit to
+        # a neighbouring target to exercise the argmax step.
+        for b in range(4):
+            qs = b * 200
+            ts = (q // n_targets) * 400 + b * 200
+            records.append(
+                PafRecord.from_line(
+                    f'q{q}\t2000\t{qs}\t{qs + 180}\t+\t'
+                    f't{best_t}\t{t_len}\t{ts}\t{ts + 180}\t170\t180\t255'
+                )
+            )
+        other_t = (best_t + 1) % n_targets
+        records.append(
+            PafRecord.from_line(
+                f'q{q}\t2000\t900\t920\t+\tt{other_t}\t{t_len}\t50\t70\t18\t20\t255'
+            )
+        )
+    return records
+
+
+_RECORDS = _synthetic_records()
+_QUERIES = [f'q{q}' for q in range(40)]
+_TARGETS = [f't{t}' for t in range(4)]
+
+
+def test_bench_compute_gravity_contigs(benchmark):
+    """Benchmark the pure-Python gravity sort + reversal detection."""
+    benchmark(lambda: compute_gravity_contigs(_RECORDS, _QUERIES, _TARGETS))

--- a/python/rusty_dot/__init__.py
+++ b/python/rusty_dot/__init__.py
@@ -36,7 +36,9 @@ from rusty_dot.paf_io import (  # noqa: F401
     PafAlignment,
     PafRecord,
     compute_gravity_contigs,
+    compute_reversed_contigs,
     parse_paf_file,
+    reverse_complement,
 )
 
 __version__ = '0.1.0'
@@ -48,6 +50,8 @@ __all__ = [
     'PafAlignment',
     'parse_paf_file',
     'compute_gravity_contigs',
+    'compute_reversed_contigs',
+    'reverse_complement',
     'GffAnnotation',
     'GffFeature',
     'py_read_fasta',

--- a/python/rusty_dot/_rusty_dot.pyi
+++ b/python/rusty_dot/_rusty_dot.pyi
@@ -215,6 +215,29 @@ class SequenceIndex:
         """
         ...
 
+    def get_sequence(self, name: str) -> str:
+        """Return the stored sequence bases for a named sequence.
+
+        Yields the original bases retained when the sequence was added, decoded
+        as a string.  Used to write (optionally reordered and reoriented) FASTA.
+
+        Parameters
+        ----------
+        name : str
+            The sequence identifier.
+
+        Returns
+        -------
+        str
+            The sequence bases.
+
+        Raises
+        ------
+        KeyError
+            If ``name`` is not present in the index.
+        """
+        ...
+
     def compare_sequences(
         self,
         query_name: str,
@@ -381,11 +404,16 @@ class SequenceIndex:
     ) -> tuple[list[str], list[str]]:
         """Return query and target contig names sorted for maximum collinearity.
 
-        Uses the gravity-centre algorithm: for each query contig the gravity
-        is the weighted mean of target mid-point positions (normalised by
-        total target span) across all matches.  Query contigs with no matches
-        are placed at the end.  The same algorithm is applied symmetrically to
-        reorder the target contigs.
+        Uses the d-genies gravity algorithm.  Each match is weighted by
+        ``(1 + euclidean_length) ** 2`` (the euclidean length spans both axes),
+        so large collinear blocks dominate.  Every query contig is assigned to
+        its single best-matching target (the argmax of summed match weights) and
+        positioned by the squared-weighted mean of its match mid-points on the
+        concatenated target axis, using only the matches to that best target.
+        Contigs are sorted by ascending position; contigs with no matches are
+        placed at the end, ordered by descending length.  The targets are
+        reordered first (against the queries in their input order) and the
+        queries are then reordered against the freshly sorted target axis.
 
         Parameters
         ----------
@@ -397,8 +425,8 @@ class SequenceIndex:
         Returns
         -------
         tuple[list[str], list[str]]
-            ``(sorted_query_names, sorted_target_names)`` ordered by ascending
-            gravity centre.
+            ``(sorted_query_names, sorted_target_names)`` ordered for maximum
+            collinearity along the diagonal.
 
         Raises
         ------

--- a/python/rusty_dot/dotplot.py
+++ b/python/rusty_dot/dotplot.py
@@ -9,6 +9,7 @@ Reference: https://github.com/rrwick/Autocycler/blob/b0523350898faac71686251ec58
 
 from __future__ import annotations
 
+import dataclasses
 import logging
 from pathlib import Path
 from typing import TYPE_CHECKING, Optional, Union
@@ -21,7 +22,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 
 from rusty_dot._rusty_dot import SequenceIndex
-from rusty_dot.paf_io import PafAlignment
+from rusty_dot.paf_io import CrossIndex, PafAlignment
 
 if TYPE_CHECKING:
     from rusty_dot.annotation import GffAnnotation
@@ -419,6 +420,7 @@ class DotPlotter:
         chain_gap: int = 0,
         rasterized: Union[bool, str] = 'auto',
         rasterization_threshold: int = 50_000,
+        reverse_contigs: Optional[set[str]] = None,
     ) -> matplotlib.figure.Figure:
         """Plot an all-vs-all dotplot grid.
 
@@ -527,6 +529,15 @@ class DotPlotter:
         rasterization_threshold : int, optional
             Segment count per strand/panel above which ``rasterized='auto'``
             rasterises the layer.  Default is ``50_000``.
+        reverse_contigs : set[str] or None, optional
+            Un-prefixed query (row) contig names to render reverse-complemented
+            so reverse-oriented contigs read along the main diagonal.  When
+            ``None`` (default) the set is pulled automatically from the index:
+            :meth:`~rusty_dot.paf_io.CrossIndex.reversed_contigs` for the
+            *query_group* of a ``CrossIndex``, or
+            :attr:`~rusty_dot.paf_io.PafAlignment.reversed_contigs` for a
+            ``PafAlignment`` (both populated by a prior ``reorder`` call).  Pass
+            an explicit set (including ``set()`` to disable) to override.
 
         Returns
         -------
@@ -558,6 +569,17 @@ class DotPlotter:
         # Use the per-call override if available, otherwise fall back to the
         # paf_alignment set at construction time.
         effective_paf = paf_override if paf_override is not None else self.paf_alignment
+
+        # Resolve the set of reverse-oriented query contigs (un-prefixed names).
+        # An explicit argument wins; otherwise auto-pull from the index.
+        if reverse_contigs is not None:
+            reverse_set = set(reverse_contigs)
+        elif isinstance(self.index, CrossIndex) and query_group is not None:
+            reverse_set = self.index.reversed_contigs(query_group)
+        elif isinstance(self.index, PafAlignment):
+            reverse_set = set(self.index.reversed_contigs)
+        else:
+            reverse_set = set()
 
         # Warn about annotation sequences missing from the index.
         if annotation is not None:
@@ -626,6 +648,7 @@ class DotPlotter:
                     chain_gap=chain_gap,
                     rasterized=rasterized,
                     rasterization_threshold=rasterization_threshold,
+                    reverse_query=self._strip_group_prefix(q_name) in reverse_set,
                 )
 
                 # Column label at top of each column (top row only), rotated.
@@ -675,6 +698,7 @@ class DotPlotter:
         chain_gap: int = 0,
         rasterized: Union[bool, str] = 'auto',
         rasterization_threshold: int = 50_000,
+        reverse_query: bool = False,
     ) -> None:
         """Render a single comparison panel onto the given Axes.
 
@@ -734,6 +758,12 @@ class DotPlotter:
         rasterization_threshold : int, optional
             Segment count above which ``rasterized='auto'`` switches a layer to
             rasterised.  Default is ``50_000``.
+        reverse_query : bool, optional
+            When ``True`` the query (row) contig is rendered reverse-complemented:
+            every match's query coordinates are mirrored (``q → q_len - q``) and
+            its strand colour flipped, so a reverse-oriented contig reads along
+            the main diagonal.  The underlying records are not modified.
+            Default is ``False``.
         """
         q_len = self.index.get_sequence_length(query_name)
         t_len = self.index.get_sequence_length(target_name)
@@ -775,6 +805,18 @@ class DotPlotter:
             # per-segment colour.  Chaining is not applied here because each
             # record carries its own identity value.
             records = self._records_for_pair(effective_paf, display_q, display_t)
+            if reverse_query:
+                # Mirror the query coordinates and flip the strand so the
+                # contig renders reverse-complemented (originals untouched).
+                records = [
+                    dataclasses.replace(
+                        rec,
+                        query_start=q_len - rec.query_end,
+                        query_end=q_len - rec.query_start,
+                        strand='-' if rec.strand == '+' else '+',
+                    )
+                    for rec in records
+                ]
             self._draw_identity_records(
                 ax,
                 records,
@@ -805,6 +847,19 @@ class DotPlotter:
                     for qs, qe, ts, te, strand in self.index.compare_sequences_stranded(
                         query_name, target_name, merge
                     )
+                ]
+            if reverse_query:
+                # Mirror the query coordinates and flip the strand so the
+                # contig renders reverse-complemented (originals untouched).
+                blocks = [
+                    (
+                        q_len - qe,
+                        q_len - qs,
+                        ts,
+                        te,
+                        '-' if strand == '+' else '+',
+                    )
+                    for qs, qe, ts, te, strand in blocks
                 ]
             if chain_gap > 0:
                 blocks = _chain_blocks(blocks, chain_gap)

--- a/python/rusty_dot/paf_io.py
+++ b/python/rusty_dot/paf_io.py
@@ -43,6 +43,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 import logging
+from math import sqrt
 from pathlib import Path
 import re
 from typing import Any, Generator, Iterable
@@ -353,24 +354,177 @@ def parse_paf_file(path: str | Path) -> Generator[PafRecord, None, None]:
 
 
 # ---------------------------------------------------------------------------
+# Sequence utilities
+# ---------------------------------------------------------------------------
+
+_COMPLEMENT = str.maketrans('ACGTNacgtn', 'TGCANtgcan')
+
+
+def reverse_complement(seq: str) -> str:
+    """Return the reverse complement of a nucleotide sequence.
+
+    Complements ``A/C/G/T/N`` (case preserved) and reverses the string.  Any
+    other character is left unchanged before reversal.
+
+    Parameters
+    ----------
+    seq : str
+        Nucleotide sequence.
+
+    Returns
+    -------
+    str
+        The reverse-complemented sequence.
+    """
+    return seq.translate(_COMPLEMENT)[::-1]
+
+
+# ---------------------------------------------------------------------------
 # Gravity-based contig reordering (pure Python)
 # ---------------------------------------------------------------------------
+
+
+def _match_weight(rec: PafRecord) -> float:
+    """Return the squared d-genies gravity weight of one alignment record.
+
+    The weight is ``(1 + euclidean_length) ** 2`` where the euclidean length
+    spans both axes: ``sqrt((target_end - target_start)**2 +
+    (query_end - query_start)**2)``.  Large collinear blocks dominate, so a
+    contig's best chromosome and sort position are driven by its major
+    alignments rather than short spurious hits.
+
+    Parameters
+    ----------
+    rec : PafRecord
+        Alignment record.
+
+    Returns
+    -------
+    float
+        The squared match weight (always ``>= 1``).
+    """
+    dt = float(rec.target_end - rec.target_start)
+    dq = float(rec.query_end - rec.query_start)
+    return (1.0 + sqrt(dt * dt + dq * dq)) ** 2
+
+
+def _gravity_order(
+    items: list[str],
+    others: list[str],
+    matches: dict[tuple[str, str], list[PafRecord]],
+    len_map: dict[str, int],
+    self_is_query: bool,
+) -> tuple[list[str], dict[str, str | None]]:
+    """Order *items* along the concatenated *others* axis by gravity centre.
+
+    Mirrors the Rust ``gravity_order`` helper.  Each item is assigned to its
+    best-matching *other* (argmax of summed squared match weights) and
+    positioned by the squared-weighted mean of its match mid-points on the
+    concatenated *other* axis, using only the matches to that best other.
+    Matched items sort by ascending position (ties broken by descending length
+    then name); items with no matches sort last, by descending length then name.
+
+    Parameters
+    ----------
+    items : list[str]
+        Names to order (the "self" axis).
+    others : list[str]
+        Reference names defining the concatenated other axis, in display order.
+    matches : dict[tuple[str, str], list[PafRecord]]
+        Records keyed by ``(query_name, target_name)``.
+    len_map : dict[str, int]
+        Sequence lengths for every name (self and other).
+    self_is_query : bool
+        When ``True`` items are queries and the other axis is the target;
+        when ``False`` items are targets and the other axis is the query.
+
+    Returns
+    -------
+    tuple[list[str], dict[str, str | None]]
+        ``(ordered_names, best_other)`` where *best_other* maps each item to
+        its argmax other (``None`` if the item has no matches).
+    """
+    # Cumulative offsets so each mid-point becomes an absolute coordinate along
+    # the concatenated other axis (in the given *others* order).
+    offsets: dict[str, int] = {}
+    acc = 0
+    for o in others:
+        offsets[o] = acc
+        acc += len_map.get(o, 1)
+    total_other = max(acc, 1)
+
+    def _key(it: str, o: str) -> tuple[str, str]:
+        return (it, o) if self_is_query else (o, it)
+
+    def _mid(rec: PafRecord) -> float:
+        if self_is_query:
+            return (rec.target_start + rec.target_end) / 2.0
+        return (rec.query_start + rec.query_end) / 2.0
+
+    matched: list[tuple[float, str]] = []
+    unmatched: list[str] = []
+    best_other: dict[str, str | None] = {}
+
+    for it in items:
+        # Total squared weight against each other; the first other reaching the
+        # maximum wins (strict ``>``), matching the Rust tie behaviour.
+        best_o: str | None = None
+        best_w = 0.0
+        for o in others:
+            recs = matches.get(_key(it, o))
+            if not recs:
+                continue
+            w = sum(_match_weight(r) for r in recs)
+            if w > best_w:
+                best_w = w
+                best_o = o
+        best_other[it] = best_o
+
+        if best_o is None:
+            unmatched.append(it)
+            continue
+
+        recs = matches[_key(it, best_o)]
+        offset = offsets[best_o]
+        wsum = 0.0
+        wpos = 0.0
+        for r in recs:
+            w = _match_weight(r)
+            wsum += w
+            wpos += w * (offset + _mid(r))
+        pos = wpos / wsum / total_other
+        matched.append((pos, it))
+
+    # Matched: ascending gravity, then descending length, then name.
+    matched.sort(key=lambda p: (p[0], -len_map.get(p[1], 0), p[1]))
+    # Unmatched: descending length, then name.
+    unmatched.sort(key=lambda n: (-len_map.get(n, 0), n))
+
+    ordered = [n for _, n in matched] + unmatched
+    return ordered, best_other
 
 
 def compute_gravity_contigs(
     records: Iterable[PafRecord],
     query_names: list[str],
     target_names: list[str],
-) -> tuple[list[str], list[str]]:
-    """Return query and target contig names sorted by gravity centre.
+    sort_targets: bool = True,
+) -> tuple[list[str], list[str], set[str]]:
+    """Return query/target contigs sorted by gravity centre, plus reversed set.
 
-    For each query contig the gravity centre is the weighted mean of target
-    mid-point positions (normalised by the total target span) across all
-    alignment records that involve that contig.  Target contigs are sorted
-    symmetrically against the query axis.
+    Implements the d-genies gravity algorithm: each contig is assigned to its
+    single best-matching chromosome (argmax of summed squared match weights,
+    ``(1 + euclidean_length) ** 2``) and positioned by the squared-weighted mean
+    of its match mid-points on the concatenated opposing axis, using only the
+    matches to that best chromosome.  Contigs are then sorted by ascending
+    position; contigs with no alignments are placed last, by descending length.
 
-    Contigs with no alignment records receive a gravity of ``float("inf")``
-    and are placed at the end of the sorted list.
+    When *sort_targets* is ``True`` (default) the targets are ordered first
+    (against the queries in their input order) and the queries are then ordered
+    against the freshly sorted target axis, so contigs group according to the
+    displayed target arrangement.  When ``False`` the target order is treated as
+    fixed (returned unchanged) and only the queries are reordered against it —
+    use this to reorder one assembly against another that must not move.
 
     Parameters
     ----------
@@ -379,101 +533,126 @@ def compute_gravity_contigs(
     query_names : list[str]
         The query contig names to reorder.
     target_names : list[str]
-        The target contig names to reorder.
+        The target contig names to reorder (or to keep fixed when
+        *sort_targets* is ``False``).
+    sort_targets : bool, optional
+        Whether to reorder the targets too.  Default is ``True``.
 
     Returns
     -------
-    tuple[list[str], list[str]]
-        ``(sorted_query_names, sorted_target_names)`` ordered by ascending
-        gravity centre.
+    tuple[list[str], list[str], set[str]]
+        ``(sorted_query_names, sorted_target_names, reversed_query_names)`` where
+        *reversed_query_names* are the query contigs detected as reverse-oriented
+        against their best-matching chromosome (see
+        :func:`compute_reversed_contigs`).  *sorted_target_names* equals
+        *target_names* unchanged when *sort_targets* is ``False``.
     """
     query_set = set(query_names)
     target_set = set(target_names)
 
-    # Collect all records into a list and build sequence-length maps from them.
-    q_len_map: dict[str, int] = {}
-    t_len_map: dict[str, int] = {}
-    all_records: list[PafRecord] = []
+    # Bucket records by (query, target) and build sequence-length maps.
+    matches: dict[tuple[str, str], list[PafRecord]] = {}
+    len_map: dict[str, int] = {}
     for rec in records:
-        all_records.append(rec)
-        q_len_map[rec.query_name] = rec.query_len
-        t_len_map[rec.target_name] = rec.target_len
-
-    # Build cumulative target offsets using actual sequence lengths.
-    t_offsets: dict[str, int] = {}
-    t_off = 0
-    for t in target_names:
-        t_offsets[t] = t_off
-        t_off += t_len_map.get(t, 1)
-    total_target_len = max(t_off, 1)
-
-    # Build cumulative query offsets using actual sequence lengths.
-    q_offsets_real: dict[str, int] = {}
-    q_off = 0
-    for q in query_names:
-        q_offsets_real[q] = q_off
-        q_off += q_len_map.get(q, 1)
-    total_query_len = max(q_off, 1)
-
-    # Accumulate weighted positions.
-    q_weight: dict[str, float] = dict.fromkeys(query_names, 0.0)
-    q_wpos: dict[str, float] = dict.fromkeys(query_names, 0.0)
-    t_weight: dict[str, float] = dict.fromkeys(target_names, 0.0)
-    t_wpos: dict[str, float] = dict.fromkeys(target_names, 0.0)
-
-    for rec in all_records:
+        len_map[rec.query_name] = rec.query_len
+        len_map[rec.target_name] = rec.target_len
         if rec.query_name not in query_set or rec.target_name not in target_set:
             continue
-        size = float(rec.alignment_block_len or (rec.query_end - rec.query_start))
-        if size <= 0:
+        matches.setdefault((rec.query_name, rec.target_name), []).append(rec)
+
+    # Order targets first (others = queries in input order) unless they are held
+    # fixed, then order queries against the resulting target axis.  This
+    # asymmetry is intentional and matches the Rust implementation.
+    if sort_targets:
+        sorted_t, _ = _gravity_order(
+            target_names, query_names, matches, len_map, self_is_query=False
+        )
+    else:
+        sorted_t = list(target_names)
+    sorted_q, best_other_q = _gravity_order(
+        query_names, sorted_t, matches, len_map, self_is_query=True
+    )
+
+    reversed_q = compute_reversed_contigs(query_names, matches, len_map, best_other_q)
+    return sorted_q, sorted_t, reversed_q
+
+
+def compute_reversed_contigs(
+    query_names: list[str],
+    matches: dict[tuple[str, str], list[PafRecord]],
+    len_map: dict[str, int],
+    best_other: dict[str, str | None],
+) -> set[str]:
+    """Return query contigs that are reverse-oriented against their best target.
+
+    Ports d-genies' ``is_contig_well_oriented``: for each query contig, take its
+    matches on its best-matching chromosome, keep only "big" matches (euclidean
+    length greater than 10% of the longest match *and* at least 1% of
+    ``min(contig_len, chrom_len)``), sort them by query mid-point, and check
+    whether the target mid-point trends upward.  A contig is reverse-oriented
+    when the mean of the consecutive-pair direction signs is ``<= -0.1`` (for a
+    single big match, when that match is on the ``-`` strand).  Contigs with no
+    big matches are treated as forward (well oriented).
+
+    Parameters
+    ----------
+    query_names : list[str]
+        Query contig names to test.
+    matches : dict[tuple[str, str], list[PafRecord]]
+        Records keyed by ``(query_name, target_name)``.
+    len_map : dict[str, int]
+        Sequence lengths for every name.
+    best_other : dict[str, str | None]
+        Mapping of each query contig to its best-matching target (or ``None``).
+
+    Returns
+    -------
+    set[str]
+        Names of query contigs detected as reverse-oriented.
+    """
+    reversed_set: set[str] = set()
+    for q in query_names:
+        t = best_other.get(q)
+        if t is None:
+            continue
+        recs = matches.get((q, t), [])
+        if not recs:
             continue
 
-        # Target gravity from query's perspective.
-        t_mid = (
-            t_offsets.get(rec.target_name, 0)
-            + (rec.target_start + rec.target_end) / 2.0
-        )
-        q_weight[rec.query_name] += size
-        q_wpos[rec.query_name] += size * t_mid
+        # (query_mid, target_mid, euclidean_length, strand) per match.
+        lines = [
+            (
+                (r.query_start + r.query_end) / 2.0,
+                (r.target_start + r.target_end) / 2.0,
+                sqrt(
+                    float(r.target_end - r.target_start) ** 2
+                    + float(r.query_end - r.query_start) ** 2
+                ),
+                r.strand,
+            )
+            for r in recs
+        ]
+        max_len = max(line[2] for line in lines)
+        threshold = 0.01 * min(len_map.get(q, 1), len_map.get(t, 1))
+        selected = [
+            line for line in lines if line[2] > 0.10 * max_len and line[2] >= threshold
+        ]
 
-        # Query gravity from target's perspective.
-        q_mid = (
-            q_offsets_real.get(rec.query_name, 0)
-            + (rec.query_start + rec.query_end) / 2.0
-        )
-        t_weight[rec.target_name] += size
-        t_wpos[rec.target_name] += size * q_mid
-
-    def _gravity(name: str, wt: dict, wp: dict, total: float) -> float:
-        w = wt.get(name, 0.0)
-        return (wp.get(name, 0.0) / w / total) if w > 0 else float('inf')
-
-    def _sort_key_with_len(
-        name: str,
-        wt: dict,
-        wp: dict,
-        total: float,
-        len_map: dict,
-    ) -> tuple:
-        g = _gravity(name, wt, wp, total)
-        if g == float('inf'):
-            # Unmatched: sort after matched (1 > 0), then by descending length
-            return (1, -len_map.get(name, 0))
-        return (0, g)
-
-    sorted_q = sorted(
-        query_names,
-        key=lambda n: _sort_key_with_len(
-            n, q_weight, q_wpos, total_target_len, q_len_map
-        ),
-    )
-    sorted_t = sorted(
-        target_names,
-        key=lambda n: _sort_key_with_len(
-            n, t_weight, t_wpos, total_query_len, t_len_map
-        ),
-    )
-    return sorted_q, sorted_t
+        if len(selected) > 1:
+            selected.sort(key=lambda line: line[0])  # by query mid-point
+            signs = [
+                1 if selected[i][1] > selected[i - 1][1] else -1
+                for i in range(1, len(selected))
+            ]
+            mean_sign = sum(signs) / len(signs)
+            if mean_sign <= -0.1:  # not well oriented
+                reversed_set.add(q)
+        elif len(selected) == 1:
+            # A single big match: orientation is simply its strand.
+            if selected[0][3] == '-':
+                reversed_set.add(q)
+        # Zero big matches: ignore (treated as forward).
+    return reversed_set
 
 
 # ---------------------------------------------------------------------------
@@ -506,6 +685,9 @@ class PafAlignment:
         # Custom group assignments.  None means use the default (query_names
         # → 'a', target_names → 'b') which is computed lazily from records.
         self._groups: dict[str, list[str]] | None = None
+        # Query contigs detected as reverse-oriented by the most recent
+        # :meth:`reorder_contigs` call (empty until then).
+        self._reversed_query: set[str] = set()
 
     # ------------------------------------------------------------------
     # Constructors
@@ -824,7 +1006,9 @@ class PafAlignment:
         Returns
         -------
         tuple[list[str], list[str]]
-            ``(sorted_query_names, sorted_target_names)``.
+            ``(sorted_query_names, sorted_target_names)``.  The set of query
+            contigs detected as reverse-oriented is stored on
+            :attr:`reversed_contigs` (not returned, for backward compatibility).
 
         Raises
         ------
@@ -846,7 +1030,25 @@ class PafAlignment:
         else:
             t = target_names if target_names is not None else self.target_names
 
-        return compute_gravity_contigs(self.records, q, t)
+        sorted_q, sorted_t, reversed_q = compute_gravity_contigs(self.records, q, t)
+        self._reversed_query = reversed_q
+        return sorted_q, sorted_t
+
+    @property
+    def reversed_contigs(self) -> set[str]:
+        """Query contigs detected as reverse-oriented by :meth:`reorder_contigs`.
+
+        Empty until :meth:`reorder_contigs` has been called.  These contigs
+        align in reverse orientation against their best-matching target and can
+        be passed to :meth:`~rusty_dot.dotplot.DotPlotter.plot` via
+        ``reverse_contigs=`` to be rendered flipped along the main diagonal.
+
+        Returns
+        -------
+        set[str]
+            Names of reverse-oriented query contigs.
+        """
+        return set(self._reversed_query)
 
 
 # ---------------------------------------------------------------------------
@@ -934,6 +1136,9 @@ class CrossIndex:
         self._internal_group: dict[str, str] = {}
         # (query_group, target_group) -> list[PafRecord] from compute_matches
         self._records_by_pair: dict[tuple[str, str], list[PafRecord]] = {}
+        # group_label -> set of reverse-oriented contigs (from the last
+        # collinearity reorder that used that group as the query axis)
+        self._reversed: dict[str, set[str]] = {}
 
     @property
     def _paf_records(self) -> list[PafRecord]:
@@ -1355,12 +1560,23 @@ class CrossIndex:
                 reverse=True,
             )
 
-    def reorder_for_colinearity(self, query_group: str, target_group: str) -> None:
+    def reorder_for_colinearity(
+        self,
+        query_group: str,
+        target_group: str,
+        reorder_target: bool = True,
+    ) -> None:
         """Reorder sequences in two groups to maximise dotplot collinearity.
 
-        Uses the gravity-centre algorithm via
-        :meth:`~rusty_dot.SequenceIndex.optimal_contig_order`.  Updates
-        :attr:`contig_order` in-place for both groups.
+        Uses the d-genies gravity algorithm.  Each query contig is assigned to
+        its best-matching target chromosome, ordered by its gravity centre
+        there, and flagged if reverse-oriented (see :meth:`reversed_contigs`).
+        Updates :attr:`contig_order` in-place.
+
+        Orientation is expressed relative to the target group, which is treated
+        as the forward reference: only *query_group* contigs are flagged as
+        reversed.  Order and orientation are derived from the k-mer engine's
+        stranded matches (the ``compute_matches`` cache is forward-strand only).
 
         .. note::
             :meth:`compute_matches` must be called for ``(query_group,
@@ -1372,6 +1588,11 @@ class CrossIndex:
             Group label for the query (y-axis / rows).
         target_group : str
             Group label for the target (x-axis / columns).
+        reorder_target : bool, optional
+            When ``True`` (default) both groups are reordered.  When ``False``
+            the target group's order is left unchanged and only *query_group* is
+            reordered against it — use this to align one assembly to another
+            that must not move.  Default is ``True``.
 
         Raises
         ------
@@ -1387,17 +1608,185 @@ class CrossIndex:
                 f'No matches computed for group pair {pair!r}. '
                 'Call compute_matches() for this pair first.'
             )
-        q_internal = [
-            self._make_internal(query_group, n) for n in self._groups[query_group]
-        ]
-        t_internal = [
-            self._make_internal(target_group, n) for n in self._groups[target_group]
-        ]
-        sorted_q_int, sorted_t_int = self._index.optimal_contig_order(
-            q_internal, t_internal
+        q_names = list(self._groups[query_group])
+        t_names = list(self._groups[target_group])
+        records = self._stranded_records(query_group, target_group, q_names, t_names)
+        sorted_q, sorted_t, reversed_q = compute_gravity_contigs(
+            records, q_names, t_names, sort_targets=reorder_target
         )
-        self._groups[query_group] = [self._split_internal(n)[1] for n in sorted_q_int]
-        self._groups[target_group] = [self._split_internal(n)[1] for n in sorted_t_int]
+        self._groups[query_group] = sorted_q
+        if reorder_target:
+            self._groups[target_group] = sorted_t
+        self._reversed[query_group] = reversed_q
+
+    def _stranded_records(
+        self,
+        query_group: str,
+        target_group: str,
+        q_names: list[str],
+        t_names: list[str],
+    ) -> list[PafRecord]:
+        """Build both-strand PAF records for a group pair from the k-mer engine.
+
+        The cached ``compute_matches`` records are forward-strand only, so both
+        the gravity ordering and the reverse-orientation check are driven from
+        :meth:`~rusty_dot.SequenceIndex.compare_sequences_stranded`, which
+        reports forward and reverse matches.
+
+        Parameters
+        ----------
+        query_group, target_group : str
+            Group labels for the query and target axes.
+        q_names, t_names : list[str]
+            Un-prefixed sequence names within each group.
+
+        Returns
+        -------
+        list[PafRecord]
+            One record per stranded match block across every (query, target)
+            pair, using un-prefixed names.
+        """
+        records: list[PafRecord] = []
+        for q in q_names:
+            qi = self._make_internal(query_group, q)
+            q_len = self._index.get_sequence_length(qi)
+            for t in t_names:
+                ti = self._make_internal(target_group, t)
+                t_len = self._index.get_sequence_length(ti)
+                for qs, qe, ts, te, strand in self._index.compare_sequences_stranded(
+                    qi, ti, True
+                ):
+                    block = max(qe - qs, te - ts)
+                    records.append(
+                        PafRecord(
+                            query_name=q,
+                            query_len=q_len,
+                            query_start=qs,
+                            query_end=qe,
+                            strand=strand,
+                            target_name=t,
+                            target_len=t_len,
+                            target_start=ts,
+                            target_end=te,
+                            residue_matches=block,
+                            alignment_block_len=block,
+                            mapping_quality=255,
+                        )
+                    )
+        return records
+
+    def reversed_contigs(self, group: str) -> set[str]:
+        """Return reverse-oriented contigs for *group* from the last reorder.
+
+        Populated by :meth:`reorder_for_colinearity` and
+        :meth:`reorder_contigs` when *group* is used as the query axis.  Empty
+        for groups that have not been reordered as a query.
+
+        Parameters
+        ----------
+        group : str
+            Group label.
+
+        Returns
+        -------
+        set[str]
+            Names of reverse-oriented contigs in *group*.
+        """
+        return set(self._reversed.get(group, set()))
+
+    # ------------------------------------------------------------------
+    # FASTA output
+    # ------------------------------------------------------------------
+
+    def get_sequence(self, name: str, group: str | None = None) -> str:
+        """Return the stored sequence bases for a contig.
+
+        Parameters
+        ----------
+        name : str
+            Sequence name.  Un-prefixed when *group* is given, otherwise the
+            internal ``'group:name'`` identifier.
+        group : str or None, optional
+            Group label the sequence belongs to.  When provided, *name* is the
+            un-prefixed name.  Default is ``None``.
+
+        Returns
+        -------
+        str
+            The sequence bases.
+
+        Raises
+        ------
+        KeyError
+            If the sequence is not present in the index.
+        """
+        internal = self._make_internal(group, name) if group is not None else name
+        return self._index.get_sequence(internal)
+
+    def write_fasta(
+        self,
+        path: str | Path,
+        group: str,
+        order: list[str] | None = None,
+        reverse: set[str] | None = None,
+        line_width: int = 60,
+    ) -> None:
+        """Write a group's contigs to a FASTA file, optionally reordered/reoriented.
+
+        Contigs are written in *order* (default :attr:`contig_order` for the
+        group, as set by the most recent reorder), and any contig named in
+        *reverse* is written reverse-complemented (default
+        :meth:`reversed_contigs` for the group).  This makes the FASTA match the
+        collinearity-optimised dotplot layout: reordered along the axis and
+        reverse-oriented contigs flipped to read forward.  Reverse-complemented
+        records carry a ``reverse_complement`` note in their header description.
+
+        Parameters
+        ----------
+        path : str or pathlib.Path
+            Output FASTA path.
+        group : str
+            Group label whose contigs to write.
+        order : list[str] or None, optional
+            Ordered un-prefixed contig names to write.  Defaults to the group's
+            current :attr:`contig_order`.
+        reverse : set[str] or None, optional
+            Contig names to reverse-complement.  Defaults to the group's
+            :meth:`reversed_contigs` set.  Pass ``set()`` to disable flipping.
+        line_width : int, optional
+            Wrap sequence lines at this many bases.  ``0`` or negative writes
+            each sequence on a single line.  Default is ``60``.
+
+        Raises
+        ------
+        KeyError
+            If *group* is unknown or a requested contig is not present.
+        """
+        if group not in self._groups:
+            raise KeyError(f'Group {group!r} not found.')
+        names = list(order) if order is not None else list(self._groups[group])
+        rc_names = reverse if reverse is not None else self.reversed_contigs(group)
+
+        with open(path, 'w') as fh:
+            for name in names:
+                seq = self.get_sequence(name, group=group)
+                if name in rc_names:
+                    seq = reverse_complement(seq)
+                    fh.write(f'>{name} reverse_complement\n')
+                else:
+                    fh.write(f'>{name}\n')
+                if line_width and line_width > 0:
+                    for i in range(0, len(seq), line_width):
+                        fh.write(seq[i : i + line_width] + '\n')
+                else:
+                    fh.write(seq + '\n')
+        _log.info(
+            'CrossIndex: wrote %d contigs from group %r to %s (%d reverse-complemented)',
+            len(names),
+            group,
+            path,
+            sum(1 for n in names if n in rc_names),
+        )
 
     # ------------------------------------------------------------------
     # PAF output and match computation
@@ -1720,6 +2109,8 @@ class CrossIndex:
                 target_group,
             )
 
+        # Both labels are resolved (non-None) by the block above.
+        assert query_group is not None and target_group is not None
         pair = (query_group, target_group)
         if pair not in self._records_by_pair:
             raise ValueError(
@@ -1735,13 +2126,14 @@ class CrossIndex:
             if target_names is not None
             else list(self._groups[target_group])
         )
-        q_internal = [self._make_internal(query_group, n) for n in q_names]
-        t_internal = [self._make_internal(target_group, n) for n in t_names]
-        sorted_q_int, sorted_t_int = self._index.optimal_contig_order(
-            q_internal, t_internal
+        # Order and reverse-orientation both come from the stranded matches
+        # (the compute_matches cache is forward-strand only); the resulting
+        # order matches SequenceIndex.optimal_contig_order by construction.
+        records = self._stranded_records(query_group, target_group, q_names, t_names)
+        sorted_q, sorted_t, reversed_q = compute_gravity_contigs(
+            records, q_names, t_names
         )
-        sorted_q = [self._split_internal(n)[1] for n in sorted_q_int]
-        sorted_t = [self._split_internal(n)[1] for n in sorted_t_int]
+        self._reversed[query_group] = reversed_q
         return sorted_q, sorted_t
 
     # ------------------------------------------------------------------

--- a/src/index.rs
+++ b/src/index.rs
@@ -22,6 +22,119 @@ use std::collections::HashMap;
 /// Stranded match coordinates: (query_start, query_end, target_start, target_end, strand).
 type StrandedMatch = (usize, usize, usize, usize, String);
 
+/// Squared d-genies gravity weight of a single match: `(1 + euclidean_length)^2`,
+/// where the euclidean length spans both the query and target axes.  Large,
+/// collinear blocks dominate, so a contig's best chromosome and sort position are
+/// driven by its major alignments rather than short spurious hits.
+fn match_weight(c: &CoordPair) -> f64 {
+    let dx = c.target_end as f64 - c.target_start as f64;
+    let dy = c.query_end as f64 - c.query_start as f64;
+    let eucl = (dx * dx + dy * dy).sqrt();
+    (1.0 + eucl).powi(2)
+}
+
+/// Order `items` along the concatenated `others` axis by gravity centre, following
+/// the d-genies algorithm.
+///
+/// For each item we sum the squared match weights (`match_weight`) against every
+/// "other" and assign the item to its best-matching other (argmax of the summed
+/// weight).  Its sort position is the weighted mean of its match mid-points on the
+/// concatenated other axis, using *only* the matches to that best other, normalised
+/// by the total other length.  Matched items sort by ascending position (ties broken
+/// by descending length then name); items with no matches sort last, by descending
+/// length then name.
+///
+/// `self_is_query` selects the axis convention: the shared `match_map` is always
+/// keyed `(query, target)`, so when ordering targets we swap the lookup key and read
+/// the query-axis mid-points instead of the target-axis mid-points.
+fn gravity_order(
+    items: &[String],
+    others: &[String],
+    match_map: &HashMap<(String, String), Vec<CoordPair>>,
+    seq_len: &HashMap<String, usize>,
+    self_is_query: bool,
+) -> Vec<String> {
+    // Cumulative offsets so each match mid-point becomes an absolute coordinate
+    // along the concatenated other axis (in the given `others` order).
+    let mut other_offsets: HashMap<&str, f64> = HashMap::new();
+    let mut acc = 0f64;
+    for o in others {
+        other_offsets.insert(o.as_str(), acc);
+        acc += seq_len[o.as_str()] as f64;
+    }
+    let total_other = acc.max(1.0);
+
+    let mid_of = |c: &CoordPair| -> f64 {
+        if self_is_query {
+            (c.target_start as f64 + c.target_end as f64) / 2.0
+        } else {
+            (c.query_start as f64 + c.query_end as f64) / 2.0
+        }
+    };
+    let key_of = |it: &str, o: &str| -> (String, String) {
+        if self_is_query {
+            (it.to_string(), o.to_string())
+        } else {
+            (o.to_string(), it.to_string())
+        }
+    };
+
+    let mut matched: Vec<(f64, usize, String)> = Vec::new();
+    let mut unmatched: Vec<(usize, String)> = Vec::new();
+
+    for it in items {
+        // Total squared weight of this item against each other; pick the argmax.
+        // The first other reaching the maximum wins (strict `>`), matching the
+        // Python implementation's tie behaviour.
+        let mut best_other: Option<&str> = None;
+        let mut best_w = 0f64;
+        for o in others {
+            let ms = &match_map[&key_of(it, o)];
+            if ms.is_empty() {
+                continue;
+            }
+            let w: f64 = ms.iter().map(match_weight).sum();
+            if w > best_w {
+                best_w = w;
+                best_other = Some(o.as_str());
+            }
+        }
+
+        match best_other {
+            None => unmatched.push((seq_len[it.as_str()], it.clone())),
+            Some(bo) => {
+                let ms = &match_map[&key_of(it, bo)];
+                let offset = other_offsets[bo];
+                let mut wsum = 0f64;
+                let mut wpos = 0f64;
+                for c in ms {
+                    let w = match_weight(c);
+                    wsum += w;
+                    wpos += w * (offset + mid_of(c));
+                }
+                let pos = wpos / wsum / total_other;
+                matched.push((pos, seq_len[it.as_str()], it.clone()));
+            }
+        }
+    }
+
+    // Matched: ascending gravity, then descending length, then name (determinism).
+    matched.sort_by(|a, b| {
+        a.0.partial_cmp(&b.0)
+            .unwrap_or(std::cmp::Ordering::Equal)
+            .then_with(|| b.1.cmp(&a.1))
+            .then_with(|| a.2.cmp(&b.2))
+    });
+    // Unmatched: descending length, then name.
+    unmatched.sort_by(|a, b| b.0.cmp(&a.0).then_with(|| a.1.cmp(&b.1)));
+
+    matched
+        .into_iter()
+        .map(|(_, _, n)| n)
+        .chain(unmatched.into_iter().map(|(_, n)| n))
+        .collect()
+}
+
 /// Build the in-memory index data (rolling-hash k-mer index) for a single sequence.
 ///
 /// This is the CPU-heavy per-sequence work (a single O(n) ntHash scan building
@@ -579,6 +692,36 @@ impl SequenceIndex {
         }
     }
 
+    /// Get the stored sequence for a named sequence.
+    ///
+    /// Returns the original sequence bases retained when the sequence was added,
+    /// decoded as a UTF-8 string.  Used to write (optionally reordered and
+    /// reoriented) FASTA output.
+    ///
+    /// Parameters
+    /// ----------
+    /// name : str
+    ///     The sequence name.
+    ///
+    /// Returns
+    /// -------
+    /// str
+    ///     The sequence bases.
+    ///
+    /// Raises
+    /// ------
+    /// KeyError
+    ///     If the sequence name is not found.
+    pub fn get_sequence(&self, name: &str) -> PyResult<String> {
+        match self.sequences.get(name) {
+            Some(data) => Ok(String::from_utf8_lossy(&data.seq_bytes).into_owned()),
+            None => Err(pyo3::exceptions::PyKeyError::new_err(format!(
+                "Sequence '{}' not found in index",
+                name
+            ))),
+        }
+    }
+
     /// Find the shared k-mers between two sequences and return their coordinates.
     ///
     /// Uses the smaller k-mer set for lookup efficiency.
@@ -755,116 +898,22 @@ impl SequenceIndex {
             pair_list.iter().cloned().zip(results.into_iter()).collect()
         };
 
-        let total_target_len: usize = target_names
+        // Sequence lengths for every name involved (used for offsets and the
+        // unmatched-contig length tie-break).
+        let seq_len: HashMap<String, usize> = query_names
             .iter()
-            .map(|n| self.sequences[n.as_str()].seq_len)
-            .sum::<usize>()
-            .max(1);
-
-        // Build cumulative target offsets so we can express each target position as an
-        // absolute coordinate across the concatenated target.
-        let mut target_offsets: HashMap<String, usize> = HashMap::new();
-        let mut offset = 0usize;
-        for n in &target_names {
-            target_offsets.insert(n.clone(), offset);
-            offset += self.sequences[n.as_str()].seq_len;
-        }
-
-        // Gravity of each query contig = weighted mean of match mid-points on the target axis.
-        let mut q_gravity: Vec<(f64, String)> = Vec::new();
-        for q in &query_names {
-            let mut weight_sum = 0.0f64;
-            let mut weighted_pos = 0.0f64;
-            for t in &target_names {
-                let matches = &match_map[&(q.clone(), t.clone())];
-                let t_offset = *target_offsets.get(t).unwrap_or(&0) as f64;
-                for c in matches {
-                    let size = (c.target_end - c.target_start) as f64;
-                    let mid = t_offset + (c.target_start as f64 + c.target_end as f64) / 2.0;
-                    weighted_pos += size * mid;
-                    weight_sum += size;
-                }
-            }
-            let gravity = if weight_sum > 0.0 {
-                weighted_pos / weight_sum / total_target_len as f64
-            } else {
-                f64::MAX // unmatched contigs sort to the end
-            };
-            q_gravity.push((gravity, q.clone()));
-        }
-        // Sort: matched contigs by ascending gravity, then unmatched by descending length.
-        let mut matched_q: Vec<(f64, String)> = q_gravity
-            .iter()
-            .filter(|(g, _)| *g < f64::MAX)
-            .cloned()
-            .collect();
-        let mut unmatched_q: Vec<(usize, String)> = q_gravity
-            .iter()
-            .filter(|(g, _)| *g >= f64::MAX)
-            .map(|(_, n)| (self.sequences[n.as_str()].seq_len, n.clone()))
-            .collect();
-        matched_q.sort_by(|a, b| a.0.partial_cmp(&b.0).unwrap_or(std::cmp::Ordering::Equal));
-        unmatched_q.sort_by_key(|b| std::cmp::Reverse(b.0)); // descending length
-        let q_gravity: Vec<String> = matched_q
-            .into_iter()
-            .map(|(_, n)| n)
-            .chain(unmatched_q.into_iter().map(|(_, n)| n))
+            .chain(target_names.iter())
+            .map(|n| (n.clone(), self.sequences[n.as_str()].seq_len))
             .collect();
 
-        let total_query_len: usize = query_names
-            .iter()
-            .map(|n| self.sequences[n.as_str()].seq_len)
-            .sum::<usize>()
-            .max(1);
+        // d-genies groups query contigs against the *displayed* target order, so we
+        // order the targets first (using the queries in their input order for the
+        // concatenated query axis) and then order the queries against the freshly
+        // sorted target axis.  This asymmetry is intentional and deterministic.
+        let sorted_t = gravity_order(&target_names, &query_names, &match_map, &seq_len, false);
+        let sorted_q = gravity_order(&query_names, &sorted_t, &match_map, &seq_len, true);
 
-        let mut query_offsets: HashMap<String, usize> = HashMap::new();
-        let mut q_offset = 0usize;
-        for n in &query_names {
-            query_offsets.insert(n.clone(), q_offset);
-            q_offset += self.sequences[n.as_str()].seq_len;
-        }
-
-        let mut t_gravity: Vec<(f64, String)> = Vec::new();
-        for t in &target_names {
-            let mut weight_sum = 0.0f64;
-            let mut weighted_pos = 0.0f64;
-            for q in &query_names {
-                let matches = &match_map[&(q.clone(), t.clone())];
-                let q_offset = *query_offsets.get(q).unwrap_or(&0) as f64;
-                for c in matches {
-                    let size = (c.query_end - c.query_start) as f64;
-                    let mid = q_offset + (c.query_start as f64 + c.query_end as f64) / 2.0;
-                    weighted_pos += size * mid;
-                    weight_sum += size;
-                }
-            }
-            let gravity = if weight_sum > 0.0 {
-                weighted_pos / weight_sum / total_query_len as f64
-            } else {
-                f64::MAX
-            };
-            t_gravity.push((gravity, t.clone()));
-        }
-        // Sort: matched contigs by ascending gravity, then unmatched by descending length.
-        let mut matched_t: Vec<(f64, String)> = t_gravity
-            .iter()
-            .filter(|(g, _)| *g < f64::MAX)
-            .cloned()
-            .collect();
-        let mut unmatched_t: Vec<(usize, String)> = t_gravity
-            .iter()
-            .filter(|(g, _)| *g >= f64::MAX)
-            .map(|(_, n)| (self.sequences[n.as_str()].seq_len, n.clone()))
-            .collect();
-        matched_t.sort_by(|a, b| a.0.partial_cmp(&b.0).unwrap_or(std::cmp::Ordering::Equal));
-        unmatched_t.sort_by_key(|b| std::cmp::Reverse(b.0)); // descending length
-        let t_gravity: Vec<String> = matched_t
-            .into_iter()
-            .map(|(_, n)| n)
-            .chain(unmatched_t.into_iter().map(|(_, n)| n))
-            .collect();
-
-        Ok((q_gravity, t_gravity))
+        Ok((sorted_q, sorted_t))
     }
 
     /// Get PAF-formatted strings for a pair of sequences.
@@ -1065,5 +1114,86 @@ impl SequenceIndex {
             self.k,
             self.sequences.len()
         )
+    }
+}
+
+#[cfg(test)]
+mod gravity_tests {
+    use super::*;
+
+    /// Build a forward-strand `CoordPair` (strand is irrelevant to gravity).
+    fn cp(qs: usize, qe: usize, ts: usize, te: usize) -> CoordPair {
+        CoordPair {
+            query_start: qs,
+            query_end: qe,
+            target_start: ts,
+            target_end: te,
+            strand: b'+',
+        }
+    }
+
+    #[test]
+    fn match_weight_is_one_plus_euclidean_squared() {
+        // Target span 3, query span 4 -> euclidean length 5 -> (1 + 5)^2 = 36.
+        let w = match_weight(&cp(0, 4, 0, 3));
+        assert!((w - 36.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn best_chromosome_argmax_ignores_small_hits() {
+        // `q` has five tiny hits to `tA` but one big hit to `tB`; squared
+        // weighting makes `tB` its best chromosome, so it sorts after `q2`
+        // (which maps to the start of `tA`) on the concatenated [tA, tB] axis.
+        let mut mm: HashMap<(String, String), Vec<CoordPair>> = HashMap::new();
+        let small: Vec<CoordPair> = (0..5)
+            .map(|i| cp(100 + i * 10, 110 + i * 10, 100 + i * 10, 110 + i * 10))
+            .collect();
+        mm.insert(("q".into(), "tA".into()), small);
+        mm.insert(("q".into(), "tB".into()), vec![cp(300, 800, 400, 900)]);
+        mm.insert(("q2".into(), "tA".into()), vec![cp(0, 400, 0, 400)]);
+        mm.insert(("q2".into(), "tB".into()), vec![]);
+        let seq_len: HashMap<String, usize> = [
+            ("q".to_string(), 900usize),
+            ("q2".to_string(), 500),
+            ("tA".to_string(), 1000),
+            ("tB".to_string(), 1000),
+        ]
+        .into_iter()
+        .collect();
+        let order = gravity_order(
+            &["q".to_string(), "q2".to_string()],
+            &["tA".to_string(), "tB".to_string()],
+            &mm,
+            &seq_len,
+            true,
+        );
+        assert_eq!(order, vec!["q2".to_string(), "q".to_string()]);
+    }
+
+    #[test]
+    fn unmatched_sorts_last_by_descending_length() {
+        let mut mm: HashMap<(String, String), Vec<CoordPair>> = HashMap::new();
+        mm.insert(("m".into(), "t".into()), vec![cp(0, 100, 0, 100)]);
+        mm.insert(("u_long".into(), "t".into()), vec![]);
+        mm.insert(("u_short".into(), "t".into()), vec![]);
+        let seq_len: HashMap<String, usize> = [
+            ("m".to_string(), 100usize),
+            ("u_long".to_string(), 500),
+            ("u_short".to_string(), 50),
+            ("t".to_string(), 1000),
+        ]
+        .into_iter()
+        .collect();
+        let order = gravity_order(
+            &["u_short".to_string(), "u_long".to_string(), "m".to_string()],
+            &["t".to_string()],
+            &mm,
+            &seq_len,
+            true,
+        );
+        assert_eq!(
+            order,
+            vec!["m".to_string(), "u_long".to_string(), "u_short".to_string()]
+        );
     }
 }

--- a/tests/test_dotplot.py
+++ b/tests/test_dotplot.py
@@ -1235,3 +1235,74 @@ def test_plot_panel_chain_gap_reduces_segments():
 
     assert n_unchained > 0
     assert n_chained <= n_unchained
+
+
+# ---------------------------------------------------------------------------
+# Reverse-oriented contig rendering (GAP 3)
+# ---------------------------------------------------------------------------
+
+
+def _forward_paf_alignment():
+    """A PafAlignment with a single forward match: query 0-50 → target 0-50."""
+    from rusty_dot.paf_io import PafAlignment, PafRecord
+
+    rec = PafRecord.from_line('q\t100\t0\t50\t+\tt\t100\t0\t50\t48\t50\t255')
+    return PafAlignment.from_records([rec])
+
+
+def test_reverse_contig_mirrors_query_axis():
+    """reverse_contigs mirrors the query coordinates (q → q_len - q)."""
+    aln = _forward_paf_alignment()
+    plotter = DotPlotter(aln)
+
+    fig_fwd = plotter.plot(query_names=['q'], target_names=['t'])
+    fwd_segs = _panel_segments(fig_fwd.axes[0])
+    plt.close(fig_fwd)
+
+    fig_rev = plotter.plot(query_names=['q'], target_names=['t'], reverse_contigs={'q'})
+    rev_segs = _panel_segments(fig_rev.axes[0])
+    plt.close(fig_rev)
+
+    assert fwd_segs and rev_segs
+    # Forward match occupies query 0-50; the reversed rendering mirrors it to
+    # query 50-100 (q_len = 100), so the maximum y-coordinate jumps to ~100.
+    fwd_max_y = max(max(s[1], s[3]) for s in fwd_segs)
+    rev_max_y = max(max(s[1], s[3]) for s in rev_segs)
+    assert fwd_max_y == 50
+    assert rev_max_y == 100
+
+
+def test_reverse_contigs_empty_leaves_unchanged():
+    """Passing an empty set leaves the panel identical to the default."""
+    aln = _forward_paf_alignment()
+    plotter = DotPlotter(aln)
+
+    fig_a = plotter.plot(query_names=['q'], target_names=['t'])
+    segs_a = _panel_segments(fig_a.axes[0])
+    plt.close(fig_a)
+
+    fig_b = plotter.plot(query_names=['q'], target_names=['t'], reverse_contigs=set())
+    segs_b = _panel_segments(fig_b.axes[0])
+    plt.close(fig_b)
+
+    assert segs_a == segs_b
+
+
+def test_reverse_contigs_auto_from_pafalignment():
+    """When reverse_contigs is None the set is pulled from the PafAlignment."""
+    from rusty_dot.paf_io import PafAlignment, PafRecord
+
+    recs = [
+        PafRecord.from_line('qr\t300\t0\t150\t-\tref\t1000\t850\t1000\t140\t150\t255'),
+        PafRecord.from_line('qr\t300\t150\t300\t-\tref\t1000\t700\t850\t140\t150\t255'),
+    ]
+    aln = PafAlignment.from_records(recs)
+    aln.reorder_contigs(['qr'], ['ref'])  # populates reversed_contigs
+    assert aln.reversed_contigs == {'qr'}
+
+    plotter = DotPlotter(aln)
+    # No reverse_contigs argument → auto-pull flags 'qr' as reversed.
+    fig = plotter.plot(query_names=['qr'], target_names=['ref'])
+    segs = _panel_segments(fig.axes[0])
+    plt.close(fig)
+    assert segs  # rendered without error using the auto-detected reversed set

--- a/tests/test_gravity_parity.py
+++ b/tests/test_gravity_parity.py
@@ -1,0 +1,96 @@
+"""Parity tests for the Rust and Python gravity-order implementations.
+
+The collinearity sort is implemented twice: in Rust
+(:meth:`rusty_dot.SequenceIndex.optimal_contig_order`, used by ``CrossIndex``)
+and in pure Python (:func:`rusty_dot.paf_io.compute_gravity_contigs`, used by
+``PafAlignment``).  Both must produce identical orderings for the same matches.
+
+To make the two engines genuinely comparable, the PAF records fed to the Python
+path are derived directly from the Rust index's own stranded matches, so both
+sides operate on exactly the same alignment blocks.
+"""
+
+from rusty_dot._rusty_dot import SequenceIndex
+from rusty_dot.paf_io import PafRecord, compute_gravity_contigs
+
+
+def _records_from_index(
+    idx: SequenceIndex,
+    query_names: list[str],
+    target_names: list[str],
+) -> list[PafRecord]:
+    """Build PAF records from the index's own merged stranded matches.
+
+    Parameters
+    ----------
+    idx : SequenceIndex
+        Populated index.
+    query_names, target_names : list[str]
+        Sequence names to compare pairwise.
+
+    Returns
+    -------
+    list[PafRecord]
+        One record per merged match block across every (query, target) pair.
+    """
+    records: list[PafRecord] = []
+    for q in query_names:
+        q_len = idx.get_sequence_length(q)
+        for t in target_names:
+            t_len = idx.get_sequence_length(t)
+            for qs, qe, ts, te, strand in idx.compare_sequences_stranded(q, t, True):
+                block = max(qe - qs, te - ts)
+                line = (
+                    f'{q}\t{q_len}\t{qs}\t{qe}\t{strand}\t'
+                    f'{t}\t{t_len}\t{ts}\t{te}\t{block}\t{block}\t255'
+                )
+                records.append(PafRecord.from_line(line))
+    return records
+
+
+def _make_index() -> SequenceIndex:
+    """Build a multi-sequence index with matches spread across targets."""
+    idx = SequenceIndex(k=11)
+    a = (
+        'ACGTTGCAAGGCCTTAGCTAGGATCCGATCGATTACGGCATGCATTGCACGTAGCTAGCATCG'
+        'TTAGGCATCCGATTGACCGATACGGATTCAGCTAGGCATTACGGATCCGATTAGCACGTATGC'
+    )
+    b = (
+        'GGATCCTTACGAGCATTGCACCGATTAGGCATCGATCGATTAGCACGTATGCATTGCAAGGCC'
+        'TTAGCTAGGATCCGATCGATTACGGCATGCATTGCACGTAGCTAGCATCGTTAGGCATCCGAT'
+    )
+    idx.add_sequence('tA', a)
+    idx.add_sequence('tB', b)
+    idx.add_sequence('qA', a)  # maps to tA
+    idx.add_sequence('qB', b)  # maps to tB
+    idx.add_sequence('qAB', a[:60] + b[:60])  # maps to both, tA dominant
+    return idx
+
+
+def _assert_parity(idx, query_names, target_names):
+    rust_q, rust_t = idx.optimal_contig_order(list(query_names), list(target_names))
+    records = _records_from_index(idx, query_names, target_names)
+    py_q, py_t, _reversed = compute_gravity_contigs(
+        records, list(query_names), list(target_names)
+    )
+    assert rust_q == py_q, f'query order differs: rust={rust_q} python={py_q}'
+    assert rust_t == py_t, f'target order differs: rust={rust_t} python={py_t}'
+
+
+def test_parity_two_targets_multi_contig():
+    """Rust and Python agree on a multi-target, multi-contig layout."""
+    idx = _make_index()
+    _assert_parity(idx, ['qB', 'qAB', 'qA'], ['tB', 'tA'])
+
+
+def test_parity_with_unmatched_contig():
+    """Parity holds when an unmatched contig must sort last by length."""
+    idx = _make_index()
+    idx.add_sequence('qNone', 'A' * 150)  # no shared k-mers → unmatched
+    _assert_parity(idx, ['qNone', 'qA', 'qB'], ['tA', 'tB'])
+
+
+def test_parity_single_target():
+    """Parity holds in the degenerate single-target case."""
+    idx = _make_index()
+    _assert_parity(idx, ['qB', 'qA', 'qAB'], ['tA'])

--- a/tests/test_paf_io.py
+++ b/tests/test_paf_io.py
@@ -10,6 +10,7 @@ from rusty_dot.paf_io import (
     PafAlignment,
     PafRecord,
     compute_gravity_contigs,
+    compute_reversed_contigs,
     parse_paf_file,
 )
 
@@ -249,7 +250,7 @@ class TestComputeGravityContigs:
 
     def test_collinear_order(self):
         records = self._make_records()
-        q_sorted, t_sorted = compute_gravity_contigs(
+        q_sorted, t_sorted, _reversed = compute_gravity_contigs(
             records, ['q_late', 'q_early'], ['target']
         )
         # q_early has lower gravity (maps to start of target) → sorts first
@@ -259,7 +260,7 @@ class TestComputeGravityContigs:
     def test_no_match_sorts_last(self):
         records = self._make_records()
         # Add a query contig that has no matches
-        q_sorted, _ = compute_gravity_contigs(
+        q_sorted, _t, _reversed = compute_gravity_contigs(
             records, ['q_late', 'q_early', 'q_none'], ['target']
         )
         assert q_sorted[-1] == 'q_none'
@@ -272,7 +273,9 @@ class TestComputeGravityContigs:
                 'query\t100\t60\t100\t+\tt_early\t40\t0\t40\t38\t40\t255'
             ),
         ]
-        _, t_sorted = compute_gravity_contigs(records, ['query'], ['t_late', 't_early'])
+        _q, t_sorted, _reversed = compute_gravity_contigs(
+            records, ['query'], ['t_late', 't_early']
+        )
         # t_early maps to lower query positions (60–100 mid=80, t_late mid=25)
         # With only one query, gravity = weighted mean query mid-point
         # t_early: query mid = 80 → higher gravity → sorts after t_late
@@ -865,10 +868,340 @@ class TestComputeGravityContigsUnmatchedLength:
         # Add two unmatched queries: long_unmatched (100 bp) and short_unmatched (10 bp)
         # Neither appears in records → len_map has no entry → length 0 for both
         # In this edge case they sort equal; just verify they're both at the end.
-        q_sorted, _ = compute_gravity_contigs(
+        q_sorted, _t, _reversed = compute_gravity_contigs(
             records,
             ['q_early', 'long_unmatched', 'short_unmatched'],
             ['target'],
         )
         assert q_sorted[0] == 'q_early'
         assert set(q_sorted[1:]) == {'long_unmatched', 'short_unmatched'}
+
+
+# ---------------------------------------------------------------------------
+# Best-matching chromosome (argmax) + squared weighting
+# ---------------------------------------------------------------------------
+
+
+class TestBestMatchingChromosome:
+    def test_argmax_uses_best_chromosome(self):
+        """A contig's best chromosome is its single big match's target, not the
+        many small hits on another chromosome (squared weighting + argmax)."""
+        from rusty_dot.paf_io import _gravity_order
+
+        # q_multi has five tiny hits on chrA but one large hit on chrB.  Squared
+        # weighting makes the single big block dominate, so argmax → chrB.
+        recs = [
+            PafRecord.from_line(
+                f'q_multi\t900\t{100 + i * 10}\t{110 + i * 10}\t+\t'
+                f'chrA\t1000\t{100 + i * 10}\t{110 + i * 10}\t9\t10\t255'
+            )
+            for i in range(5)
+        ]
+        recs.append(
+            PafRecord.from_line(
+                'q_multi\t900\t300\t800\t+\tchrB\t1000\t400\t900\t480\t500\t255'
+            )
+        )
+        matches: dict = {}
+        for r in recs:
+            matches.setdefault((r.query_name, r.target_name), []).append(r)
+        len_map = {'q_multi': 900, 'chrA': 1000, 'chrB': 1000}
+        _ordered, best_other = _gravity_order(
+            ['q_multi'], ['chrA', 'chrB'], matches, len_map, self_is_query=True
+        )
+        assert best_other['q_multi'] == 'chrB'
+
+    def test_tie_breaks_by_descending_length(self):
+        """Two contigs at the same gravity position sort by descending length."""
+        recs = [
+            PafRecord.from_line(
+                'q_short\t100\t0\t50\t+\tt\t1000\t100\t200\t48\t50\t255'
+            ),
+            PafRecord.from_line(
+                'q_long\t500\t0\t50\t+\tt\t1000\t100\t200\t48\t50\t255'
+            ),
+        ]
+        q_sorted, _t, _rev = compute_gravity_contigs(recs, ['q_short', 'q_long'], ['t'])
+        # Identical target mid-point → equal gravity → longer contig first.
+        assert q_sorted == ['q_long', 'q_short']
+
+
+# ---------------------------------------------------------------------------
+# Reverse-orientation detection (compute_reversed_contigs / gravity 3-tuple)
+# ---------------------------------------------------------------------------
+
+
+class TestReversedContigDetection:
+    def _reversed_from(self, records, q, t):
+        _sq, _st, reversed_q = compute_gravity_contigs(records, q, t)
+        return reversed_q
+
+    def test_reverse_oriented_contig_detected(self):
+        """A contig whose target position decreases as query increases is flagged."""
+        recs = [
+            PafRecord.from_line(
+                'qr\t300\t0\t100\t-\tref\t1000\t900\t1000\t95\t100\t255'
+            ),
+            PafRecord.from_line(
+                'qr\t300\t100\t200\t-\tref\t1000\t800\t900\t95\t100\t255'
+            ),
+            PafRecord.from_line(
+                'qr\t300\t200\t300\t-\tref\t1000\t700\t800\t95\t100\t255'
+            ),
+        ]
+        assert self._reversed_from(recs, ['qr'], ['ref']) == {'qr'}
+
+    def test_forward_contig_not_reversed(self):
+        """A contig whose target position increases with query is not flagged."""
+        recs = [
+            PafRecord.from_line('qf\t300\t0\t100\t+\tref\t1000\t0\t100\t95\t100\t255'),
+            PafRecord.from_line(
+                'qf\t300\t100\t200\t+\tref\t1000\t100\t200\t95\t100\t255'
+            ),
+            PafRecord.from_line(
+                'qf\t300\t200\t300\t+\tref\t1000\t200\t300\t95\t100\t255'
+            ),
+        ]
+        assert self._reversed_from(recs, ['qf'], ['ref']) == set()
+
+    def test_small_noise_match_does_not_flip(self):
+        """A tiny reverse noise match below the 10% threshold is ignored."""
+        recs = [
+            # One dominant forward match.
+            PafRecord.from_line('q\t300\t0\t200\t+\tref\t1000\t0\t200\t190\t200\t255'),
+            # Tiny reverse hit: euclidean length far below 10% of the big match.
+            PafRecord.from_line('q\t300\t210\t215\t-\tref\t1000\t505\t500\t4\t5\t255'),
+        ]
+        assert self._reversed_from(recs, ['q'], ['ref']) == set()
+
+    def test_single_big_reverse_match_flagged(self):
+        """A single dominant reverse-strand match flags the contig as reversed."""
+        recs = [
+            PafRecord.from_line('q\t300\t0\t250\t-\tref\t1000\t0\t250\t240\t250\t255'),
+        ]
+        assert self._reversed_from(recs, ['q'], ['ref']) == {'q'}
+
+    def test_compute_reversed_contigs_direct(self):
+        """The standalone helper agrees with the gravity-tuple result."""
+        recs = [
+            PafRecord.from_line(
+                'qr\t300\t0\t150\t-\tref\t1000\t850\t1000\t140\t150\t255'
+            ),
+            PafRecord.from_line(
+                'qr\t300\t150\t300\t-\tref\t1000\t700\t850\t140\t150\t255'
+            ),
+        ]
+        matches = {('qr', 'ref'): recs}
+        len_map = {'qr': 300, 'ref': 1000}
+        result = compute_reversed_contigs(['qr'], matches, len_map, {'qr': 'ref'})
+        assert result == {'qr'}
+
+
+# ---------------------------------------------------------------------------
+# reversed_contigs exposure on PafAlignment and CrossIndex
+# ---------------------------------------------------------------------------
+
+
+class TestReversedContigsAPI:
+    def test_pafalignment_reorder_returns_two_tuple(self):
+        """reorder_contigs stays a 2-tuple; reversed set lives on the property."""
+        recs = [
+            PafRecord.from_line(
+                'qr\t300\t0\t150\t-\tref\t1000\t850\t1000\t140\t150\t255'
+            ),
+            PafRecord.from_line(
+                'qr\t300\t150\t300\t-\tref\t1000\t700\t850\t140\t150\t255'
+            ),
+        ]
+        aln = PafAlignment.from_records(recs)
+        result = aln.reorder_contigs(['qr'], ['ref'])
+        assert isinstance(result, tuple) and len(result) == 2
+        assert aln.reversed_contigs == {'qr'}
+
+    def test_pafalignment_reversed_contigs_empty_before_reorder(self):
+        """The property is empty until reorder_contigs has run."""
+        recs = [
+            PafRecord.from_line('q\t100\t0\t50\t+\tref\t1000\t0\t50\t48\t50\t255'),
+        ]
+        aln = PafAlignment.from_records(recs)
+        assert aln.reversed_contigs == set()
+
+    def test_crossindex_reversed_contigs_populated(self):
+        """reorder_for_colinearity records the reverse-oriented query contigs."""
+        from rusty_dot.paf_io import CrossIndex
+
+        def revcomp(s):
+            return s.translate(str.maketrans('ACGT', 'TGCA'))[::-1]
+
+        seq = (
+            'ACGTTGCAAGGCCTTAGCTAGGATCCGATCGATTACGGCATGCATTGCACGTAGCTAGCATCG'
+            'TTAGGCATCCGATTGACCGATACGGATTCAGCTAGGCATTACGGATCCGATTAGCACGTATGC'
+        )
+        cross = CrossIndex(k=11)
+        cross.add_sequence('fwd', seq, group='a')
+        cross.add_sequence('rev', revcomp(seq), group='a')
+        cross.add_sequence('ref', seq, group='b')
+        cross.compute_matches('a', 'b')
+        cross.reorder_for_colinearity('a', 'b')
+        reversed_a = cross.reversed_contigs('a')
+        assert isinstance(reversed_a, set)
+        # The reverse-complement contig aligns on the '-' strand → flagged;
+        # the forward copy is not.
+        assert 'rev' in reversed_a
+        assert 'fwd' not in reversed_a
+
+    def test_crossindex_reversed_contigs_empty_for_unreordered_group(self):
+        """A group never used as query axis has an empty reversed set."""
+        from rusty_dot.paf_io import CrossIndex
+
+        cross = CrossIndex(k=6)
+        cross.add_sequence('q', 'ACGTACGTACGT' * 3, group='a')
+        cross.add_sequence('t', 'ACGTACGTACGT' * 3, group='b')
+        assert cross.reversed_contigs('a') == set()
+
+
+# ---------------------------------------------------------------------------
+# reverse_complement helper
+# ---------------------------------------------------------------------------
+
+
+class TestReverseComplement:
+    def test_basic(self):
+        from rusty_dot.paf_io import reverse_complement
+
+        assert reverse_complement('ACGT') == 'ACGT'
+        assert reverse_complement('AAAA') == 'TTTT'
+        assert reverse_complement('ACGTN') == 'NACGT'
+
+    def test_case_preserved(self):
+        from rusty_dot.paf_io import reverse_complement
+
+        assert reverse_complement('acgt') == 'acgt'
+        assert reverse_complement('AcgT') == 'AcgT'
+
+    def test_double_reverse_is_identity(self):
+        from rusty_dot.paf_io import reverse_complement
+
+        seq = 'ACGTTGCAAGGCCTTAGCTAGGATCCGATCG'
+        assert reverse_complement(reverse_complement(seq)) == seq
+
+
+# ---------------------------------------------------------------------------
+# compute_gravity_contigs with fixed targets (sort_targets=False)
+# ---------------------------------------------------------------------------
+
+
+class TestFixedTargetOrder:
+    def test_targets_unchanged_when_sort_targets_false(self):
+        recs = [
+            PafRecord.from_line('qB\t100\t0\t50\t+\tt2\t1000\t900\t950\t48\t50\t255'),
+            PafRecord.from_line('qA\t100\t0\t50\t+\tt1\t1000\t0\t50\t48\t50\t255'),
+        ]
+        q_sorted, t_sorted, _rev = compute_gravity_contigs(
+            recs, ['qB', 'qA'], ['t1', 't2'], sort_targets=False
+        )
+        # Targets kept exactly as given; queries reordered against that axis.
+        assert t_sorted == ['t1', 't2']
+        assert q_sorted == ['qA', 'qB']
+
+
+# ---------------------------------------------------------------------------
+# CrossIndex FASTA output + fixed-target reorder
+# ---------------------------------------------------------------------------
+
+
+def _rc(s: str) -> str:
+    return s.translate(str.maketrans('ACGT', 'TGCA'))[::-1]
+
+
+_FASTA_SEQ = (
+    'ACGTTGCAAGGCCTTAGCTAGGATCCGATCGATTACGGCATGCATTGCACGTAGCTAGCATCG'
+    'TTAGGCATCCGATTGACCGATACGGATTCAGCTAGGCATTACGGATCCGATTAGCACGTATGC'
+)
+
+
+class TestCrossIndexFasta:
+    def _cross(self):
+        from rusty_dot.paf_io import CrossIndex
+
+        cross = CrossIndex(k=11)
+        cross.add_sequence('fwd', _FASTA_SEQ, group='a')
+        cross.add_sequence('rev', _rc(_FASTA_SEQ), group='a')
+        cross.add_sequence('ref', _FASTA_SEQ, group='b')
+        cross.compute_matches('a', 'b')
+        return cross
+
+    def test_get_sequence_roundtrip(self):
+        cross = self._cross()
+        assert cross.get_sequence('fwd', group='a') == _FASTA_SEQ
+        assert cross.get_sequence('a:fwd') == _FASTA_SEQ
+
+    def _read_fasta(self, path):
+        records, name, seq = {}, None, []
+        for line in path.read_text().splitlines():
+            if line.startswith('>'):
+                if name is not None:
+                    records[name] = ''.join(seq)
+                name = line[1:].split()[0]
+                seq = []
+            else:
+                seq.append(line)
+        if name is not None:
+            records[name] = ''.join(seq)
+        return records
+
+    def test_write_fasta_reorients_reversed_contig(self, tmp_path):
+        cross = self._cross()
+        cross.reorder_for_colinearity('a', 'b')
+        assert 'rev' in cross.reversed_contigs('a')
+
+        out = tmp_path / 'a.fasta'
+        cross.write_fasta(out, 'a')
+        recs = self._read_fasta(out)
+        # 'rev' was reverse-complemented on write → matches the forward reference.
+        assert recs['rev'] == _FASTA_SEQ
+        assert recs['fwd'] == _FASTA_SEQ
+
+    def test_write_fasta_reverse_disabled(self, tmp_path):
+        cross = self._cross()
+        cross.reorder_for_colinearity('a', 'b')
+        out = tmp_path / 'a_noflip.fasta'
+        cross.write_fasta(out, 'a', reverse=set())
+        recs = self._read_fasta(out)
+        # With flipping disabled the reverse contig stays reverse-complemented.
+        assert recs['rev'] == _rc(_FASTA_SEQ)
+
+    def test_write_fasta_respects_order(self, tmp_path):
+        cross = self._cross()
+        out = tmp_path / 'a_ordered.fasta'
+        cross.write_fasta(out, 'a', order=['rev', 'fwd'], reverse=set())
+        names = [
+            line[1:].split()[0]
+            for line in out.read_text().splitlines()
+            if line.startswith('>')
+        ]
+        assert names == ['rev', 'fwd']
+
+    def test_write_fasta_line_width(self, tmp_path):
+        cross = self._cross()
+        out = tmp_path / 'wrapped.fasta'
+        cross.write_fasta(out, 'a', reverse=set(), line_width=20)
+        seq_lines = [
+            line for line in out.read_text().splitlines() if not line.startswith('>')
+        ]
+        assert all(len(line) <= 20 for line in seq_lines)
+        assert any(len(line) == 20 for line in seq_lines)
+
+    def test_write_fasta_unknown_group_raises(self, tmp_path):
+        cross = self._cross()
+        with pytest.raises(KeyError):
+            cross.write_fasta(tmp_path / 'x.fasta', 'nope')
+
+    def test_reorder_target_false_keeps_target_fixed(self):
+        cross = self._cross()
+        cross.add_sequence('ref2', _rc(_FASTA_SEQ), group='b')
+        cross.compute_matches('a', 'b')
+        before_b = list(cross.contig_order['b'])
+        cross.reorder_for_colinearity('a', 'b', reorder_target=False)
+        assert cross.contig_order['b'] == before_b  # target untouched
+        assert set(cross.contig_order['a']) == {'fwd', 'rev'}


### PR DESCRIPTION
## Summary

Three related bodies of work on contig ordering, FASTA export, and the Python toolchain.

### 1. d-genies fidelity for the gravity collinearity sort
Closes three gaps between the existing gravity sort and the d-genies reference:
- **Squared weighting** — matches are weighted by `(1 + euclidean_length)²` (spanning both axes) in both the Rust `optimal_contig_order` and the Python `compute_gravity_contigs`, so large collinear blocks dominate.
- **Best-matching chromosome (argmax)** — each contig is assigned to its single best target and positioned using only that target's matches, instead of averaging across all targets.
- **Reverse-orientation detection + rendering** — reverse-oriented query contigs are detected (`reversed_contigs()`) and rendered flipped along the main diagonal via `DotPlotter.plot(reverse_contigs=…)`, without rewriting coordinates.

### 2. Reordered / reoriented FASTA export
- `SequenceIndex.get_sequence()` and a `reverse_complement()` helper.
- `CrossIndex.write_fasta()` writes a group's contigs in `contig_order`, reverse-complementing the flagged contigs.
- `reorder_for_colinearity(reorder_target=…)` and `compute_gravity_contigs(sort_targets=…)` allow reordering one assembly against a **fixed** reference.
- New **"Writing Reordered FASTA"** tutorial with three worked cases (fix A / length-sort A / reorder both), where A is the forward reference frame.

### 3. Python 3.14 (free-threading)
- `environment.yml` → Python 3.14 + `python-freethreading`; `requires-python` bumped to `<3.15`.
- `ci.yml` and `codspeed.yml` → Python 3.14 (the wasm/Pyodide job stays on 3.12, which is what Pyodide 0.27 ships).

## Testing
- **394 pytest** + **33 cargo** tests pass on the free-threaded Python 3.14.0 build (94% coverage); `ruff`, `cargo fmt`/`clippy -D warnings` clean.
- Adds Rust gravity unit tests, Rust/Python gravity **parity** tests, DotPlotter flip tests, FASTA/reorder tests, and reorder benchmarks.
- No source changes were needed for 3.14/free-threading beyond the `requires-python` bound; PyO3 0.28 runs with the GIL disabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012tdKr9LKXQr6oCurDYUvWL
